### PR TITLE
fix: handle wasm-ld-synthesized stubs lacking reloc.CODE entries (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ## wasm_split_cli v0.2.1
 
 - Improved error messages.
+- Work around an issue with wasm-ld and LTO which does not generate relocations for all stubs, see #29.
+  Fixed in #30 by @adrianncovaci.
 
 ## wasm_split_cli v0.2.0, wasm_split_helpers v0.2.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -231,12 +237,12 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -496,6 +502,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,7 +532,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d642d8c5ecc083aafe9ceb32809276a304547a3a6eeecceb5d8152598bc71f"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.240.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]
@@ -533,8 +555,9 @@ dependencies = [
  "regex",
  "tracing",
  "tracing-subscriber",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.240.0",
+ "wasmparser 0.240.0",
+ "wat",
 ]
 
 [[package]]
@@ -566,6 +589,39 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+dependencies = [
+ "bitflags",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wast"
+version = "247.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579d2d47eb33b0cdf9b14723cb115f1e1b7d6e77aac6f0816e5b7c7aeaa418ff"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.247.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f4091c56437e86f2b57fa2fac72c4f528957a605b3f44f7c0b3b19a17ac5ee"
+dependencies = [
+ "wast",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,37 +28,37 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -75,9 +75,9 @@ checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -96,9 +96,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -130,15 +130,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cpufeatures"
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -193,9 +193,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -231,21 +231,21 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "lazy_static"
@@ -261,21 +261,21 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nu-ansi-term"
@@ -283,50 +283,50 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -347,15 +347,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -420,9 +420,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -485,15 +485,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "utf8parse"
@@ -576,83 +576,9 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "async-once-cell"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +182,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +200,12 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "foldhash"
@@ -199,6 +221,19 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -222,6 +257,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indenter"
@@ -248,6 +289,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +311,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -305,6 +358,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +384,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "regex"
@@ -350,6 +419,19 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "semver"
@@ -384,6 +466,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -427,6 +522,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -496,6 +604,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,13 +628,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d642d8c5ecc083aafe9ceb32809276a304547a3a6eeecceb5d8152598bc71f"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.240.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -531,10 +685,11 @@ dependencies = [
  "eyre",
  "lazy_static",
  "regex",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.240.0",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]
@@ -569,6 +724,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,3 +749,103 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/wasm_split_cli/Cargo.toml
+++ b/crates/wasm_split_cli/Cargo.toml
@@ -22,6 +22,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.23.0"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 [lib]
 name = "wasm_split_cli_support"

--- a/crates/wasm_split_cli/Cargo.toml
+++ b/crates/wasm_split_cli/Cargo.toml
@@ -20,6 +20,9 @@ wasmparser = "0.240"
 clap = { version = "4.5", features = ["derive"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["fmt"], optional = true }
 
+[dev-dependencies]
+tempfile = "3.23.0"
+
 [lib]
 name = "wasm_split_cli_support"
 

--- a/crates/wasm_split_cli/src/dep_graph.rs
+++ b/crates/wasm_split_cli/src/dep_graph.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use eyre::{anyhow, bail, Result};
-use wasmparser::RelocationEntry;
+use wasmparser::{FunctionBody, Operator, RelocationEntry};
 
 use crate::{
     read::{GlobalId, InputFuncId, InputModule, MemoryId, SymbolIndex, TableId, TagId},
@@ -24,7 +24,7 @@ pub enum DepNode {
 
 pub type DepGraph = HashMap<DepNode, HashSet<DepNode>>;
 
-pub fn get_dependencies(module: &InputModule) -> Result<DepGraph> {
+pub fn get_dependencies(module: &InputModule) -> Result<(DepGraph, HashSet<InputFuncId>)> {
     struct Builder<'a, 'm>(DepGraph, &'a InputModule<'m>);
     impl Builder<'_, '_> {
         fn add_dep(&mut self, a: DepNode, b: DepNode) {
@@ -51,10 +51,37 @@ pub fn get_dependencies(module: &InputModule) -> Result<DepGraph> {
     }
 
     let mut deps = Builder(DepGraph::new(), module);
+    let mut fns_with_relocs = HashSet::<InputFuncId>::new();
 
     for dep_entry in iter_functions_with_relocs(module) {
         let (func_index, entry) = dep_entry?;
+        fns_with_relocs.insert(func_index);
         deps.add_reloc_dep(DepNode::Function(func_index), entry)?;
+    }
+
+    let imported_fns_len = module.imported_funcs.len();
+    let mut stub_fns = HashSet::<InputFuncId>::new();
+    let mut unexpected_ops: HashMap<String, (usize, InputFuncId)> = HashMap::new();
+
+    for (i, defined_func) in module.defined_funcs.iter().enumerate() {
+        let idx = imported_fns_len + i;
+        if fns_with_relocs.contains(&idx) {
+            continue;
+        }
+
+        if let Some(targets) = validate_no_reloc_stub(&defined_func.body, idx, &mut unexpected_ops)?
+        {
+            stub_fns.insert(idx);
+            for target in targets {
+                deps.add_dep(DepNode::Function(idx), DepNode::Function(target));
+            }
+        }
+    }
+
+    if !unexpected_ops.is_empty() {
+        for (op, (count, sample)) in &unexpected_ops {
+            tracing::warn!("skipped {count} no-reloc stub func(s) with {op} (e.g. func[{sample}])",);
+        }
     }
 
     for dep_entry in iter_data_dependencies(module) {
@@ -91,7 +118,7 @@ pub fn get_dependencies(module: &InputModule) -> Result<DepGraph> {
             }
         }
     }
-    Ok(deps.0)
+    Ok((deps.0, stub_fns))
 }
 
 fn iter_functions_with_relocs<'m>(
@@ -116,6 +143,56 @@ fn iter_functions_with_relocs<'m>(
         let func_index = module.imported_funcs.len() + function_index;
         Ok((func_index, entry))
     })
+}
+
+fn validate_no_reloc_stub(
+    body: &FunctionBody<'_>,
+    func_id: InputFuncId,
+    unexpected_ops: &mut HashMap<String, (usize, InputFuncId)>,
+) -> Result<Option<Vec<InputFuncId>>> {
+    let mut targets = vec![];
+    let mut ops = body.get_operators_reader()?;
+    while !ops.eof() {
+        match ops.read()? {
+            Operator::Call { function_index } => targets.push(function_index as usize),
+            op @ (Operator::RefFunc { .. }
+            | Operator::ReturnCall { .. }
+            | Operator::ReturnCallIndirect { .. }
+            | Operator::CallIndirect { .. }
+            | Operator::GlobalGet { .. }
+            | Operator::GlobalSet { .. }
+            | Operator::TableGet { .. }
+            | Operator::TableSet { .. }
+            | Operator::TableSize { .. }
+            | Operator::TableGrow { .. }
+            | Operator::TableFill { .. }
+            | Operator::TableInit { .. }
+            | Operator::TableCopy { .. }
+            | Operator::MemoryInit { .. }
+            | Operator::DataDrop { .. }
+            | Operator::ElemDrop { .. }) => {
+                let name = op_short_name(&op);
+                let entry = unexpected_ops.entry(name).or_insert((0, func_id));
+                entry.0 += 1;
+                return Ok(None);
+            }
+            _ => {}
+        }
+    }
+
+    if targets.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(targets))
+}
+
+fn op_short_name(op: &Operator) -> String {
+    let dbg = format!("{op:?}");
+    dbg.split(|c: char| !c.is_alphanumeric() && c != '_')
+        .next()
+        .unwrap_or("<unknown>")
+        .to_owned()
 }
 
 enum DataDependency<'a> {

--- a/crates/wasm_split_cli/src/dep_graph.rs
+++ b/crates/wasm_split_cli/src/dep_graph.rs
@@ -82,7 +82,7 @@ pub fn get_dependencies(module: &InputModule) -> Result<(DepGraph, HashSet<Input
     if !unexpected_ops.is_empty() {
         for (op, (count, sample)) in &unexpected_ops {
             tracing::warn!(
-                "skipped {count} no-reloc stub func(s) with {op} (e.g. func[{sample}] {:?})",
+                "skipped {count} func(s) with missing reloc info, {op} looks too complicated for a stub (e.g. func[{sample}] {:?})",
                 module.names.functions.get(sample).unwrap_or(&"<anon>")
             );
         }
@@ -189,6 +189,7 @@ fn validate_no_reloc_stub(
     let mut targets = vec![];
     let mut ops = body.get_operators_reader()?;
     let mut needs_reloc_info = false;
+    let mut is_simple_stub = true;
     while !ops.eof() {
         let op = ops.read()?;
         needs_reloc_info |= surely_needs_reloc_information(&op);
@@ -203,12 +204,12 @@ fn validate_no_reloc_stub(
                 entry.0 += 1;
                 return Ok(None);
             }
-            _ => {}
+            _ => is_simple_stub = false,
         }
     }
 
     let any_targets = !targets.is_empty();
-    Ok(any_targets.then_some(targets))
+    Ok((is_simple_stub && any_targets).then_some(targets))
 }
 
 fn op_short_name(op: &Operator) -> String {

--- a/crates/wasm_split_cli/src/dep_graph.rs
+++ b/crates/wasm_split_cli/src/dep_graph.rs
@@ -59,8 +59,9 @@ pub fn get_dependencies(module: &InputModule) -> Result<(DepGraph, HashSet<Input
         deps.add_reloc_dep(DepNode::Function(func_index), entry)?;
     }
 
-    let imported_fns_len = module.imported_funcs.len();
+    // See issue #29 for why we detect stub functions that aren't covered by reloc data
     let mut stub_fns = HashSet::<InputFuncId>::new();
+    let imported_fns_len = module.imported_funcs.len();
     let mut unexpected_ops: HashMap<String, (usize, InputFuncId)> = HashMap::new();
 
     for (i, defined_func) in module.defined_funcs.iter().enumerate() {
@@ -80,7 +81,10 @@ pub fn get_dependencies(module: &InputModule) -> Result<(DepGraph, HashSet<Input
 
     if !unexpected_ops.is_empty() {
         for (op, (count, sample)) in &unexpected_ops {
-            tracing::warn!("skipped {count} no-reloc stub func(s) with {op} (e.g. func[{sample}])",);
+            tracing::warn!(
+                "skipped {count} no-reloc stub func(s) with {op} (e.g. func[{sample}] {:?})",
+                module.names.functions.get(sample).unwrap_or(&"<anon>")
+            );
         }
     }
 
@@ -150,15 +154,21 @@ fn validate_no_reloc_stub(
     func_id: InputFuncId,
     unexpected_ops: &mut HashMap<String, (usize, InputFuncId)>,
 ) -> Result<Option<Vec<InputFuncId>>> {
-    let mut targets = vec![];
-    let mut ops = body.get_operators_reader()?;
-    while !ops.eof() {
-        match ops.read()? {
-            Operator::Call { function_index } => targets.push(function_index as usize),
-            op @ (Operator::RefFunc { .. }
+    // Three reasons why a function could have no relocations:
+    // 1) it is a stub function which is missing them, as in #29
+    // 2) it is a simple function that doesn't refer to indices that need relocating.
+    // 3) it is a complex function that is missing relocation information
+    // We only want to handle the first case here, and emit warning for the third case.
+    // To keep noise down, we err on the side of classifying a function as 2) for op-codes that
+    // we don't recognize.
+    fn surely_needs_reloc_information(op: &Operator) -> bool {
+        matches!(
+            op, //
+            | Operator::Call { .. }     // part of a normal stub, anyway
             | Operator::ReturnCall { .. }
-            | Operator::ReturnCallIndirect { .. }
             | Operator::CallIndirect { .. }
+            | Operator::ReturnCallIndirect { .. }
+            | Operator::RefFunc { .. }
             | Operator::GlobalGet { .. }
             | Operator::GlobalSet { .. }
             | Operator::TableGet { .. }
@@ -170,7 +180,24 @@ fn validate_no_reloc_stub(
             | Operator::TableCopy { .. }
             | Operator::MemoryInit { .. }
             | Operator::DataDrop { .. }
-            | Operator::ElemDrop { .. }) => {
+            | Operator::ElemDrop { .. }
+        )
+        // There might be more operators to add in the future. At the moment, we miss
+        // out on a warning on even more complicated functions that do for some reason
+        // not use one of the operators above.
+    }
+    let mut targets = vec![];
+    let mut ops = body.get_operators_reader()?;
+    let mut needs_reloc_info = false;
+    while !ops.eof() {
+        let op = ops.read()?;
+        needs_reloc_info |= surely_needs_reloc_information(&op);
+        match op {
+            // We expect the following operators in a simple stub:
+            Operator::Call { function_index } => targets.push(function_index as usize),
+            Operator::LocalGet { .. } | Operator::Return | Operator::End => {}
+            // Any other operator signals a more complicated stub and will get warned on.
+            op if needs_reloc_info => {
                 let name = op_short_name(&op);
                 let entry = unexpected_ops.entry(name).or_insert((0, func_id));
                 entry.0 += 1;
@@ -180,11 +207,8 @@ fn validate_no_reloc_stub(
         }
     }
 
-    if targets.is_empty() {
-        return Ok(None);
-    }
-
-    Ok(Some(targets))
+    let any_targets = !targets.is_empty();
+    Ok(any_targets.then_some(targets))
 }
 
 fn op_short_name(op: &Operator) -> String {

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use eyre::{anyhow, bail, Context, Result};
 use tracing::{trace, warn};
-use wasm_encoder::{EntityType, ProducersField, ProducersSection};
+use wasm_encoder::{reencode::Reencode, EntityType, ProducersField, ProducersSection};
 use wasmparser::{
     BinaryReader, Data, DataKind, DefinedDataSymbol, ExternalKind, ProducersSectionReader,
     SegmentFlags, SymbolInfo, TypeRef,
@@ -27,6 +27,7 @@ pub(crate) struct EmitState<'a> {
     indirect_functions: IndirectFunctionEmitInfo,
     data_relocations: DataEmitInfo,
     shared_names: HashMap<DepNode, Cow<'a, str>>,
+    no_reloc_stubs: HashSet<InputFuncId>,
 }
 
 impl<'a> EmitState<'a> {
@@ -35,6 +36,7 @@ impl<'a> EmitState<'a> {
         module: &'a InputModule<'a>,
         program_info: &SplitProgramInfo,
         link_module: &'a str,
+        no_reloc_stubs: HashSet<InputFuncId>,
     ) -> Result<Self> {
         let indirect_functions = IndirectFunctionEmitInfo::new(module, program_info)?;
         let data_relocations = DataEmitInfo::new(module, program_info)?;
@@ -83,6 +85,7 @@ impl<'a> EmitState<'a> {
             indirect_functions,
             data_relocations,
             shared_names,
+            no_reloc_stubs,
         })
     }
 
@@ -1020,9 +1023,34 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_code_section(&mut self) -> Result<()> {
+        tracing::debug!(
+            module = self.output_module_index,
+            defined_count = self.defined_functions.len(),
+            "emitting code section",
+        );
         let mut section = wasm_encoder::CodeSection::new();
         for output_func in self.defined_functions.iter() {
             match output_func.kind {
+                OutputFunctionKind::Defined
+                    if self
+                        .emit_state
+                        .no_reloc_stubs
+                        .contains(&output_func.input_func_id) =>
+                {
+                    let body = self.input_module.defined_funcs
+                        [output_func.input_func_id - self.input_module.imported_funcs.len()]
+                    .body
+                    .clone();
+
+                    FuncReencoder {
+                        dep_to_local_index: &self.dep_to_local_index,
+                        func_id: output_func.input_func_id,
+                    }
+                    .parse_function_body(&mut section, body)
+                    .with_context(|| {
+                        format!("re-encoding no-reloc func {}", output_func.input_func_id)
+                    })?;
+                }
                 OutputFunctionKind::Defined => {
                     let input_func = &self.input_module.defined_funcs
                         [output_func.input_func_id - self.input_module.imported_funcs.len()];
@@ -1270,6 +1298,49 @@ impl<'a> ModuleEmitState<'a> {
         producers.field(PROCESSED_BY_FIELD_NAME, &produced_by);
         self.output_module.section(&producers);
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct MissingFunctionMapping {
+    stub_func: InputFuncId,
+    referenced: u32,
+}
+
+impl std::fmt::Display for MissingFunctionMapping {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "no-reloc func {} references input func {} with no output mapping",
+            self.stub_func, self.referenced,
+        )
+    }
+}
+
+impl std::error::Error for MissingFunctionMapping {}
+
+struct FuncReencoder<'a> {
+    dep_to_local_index: &'a HashMap<DepNode, InputFuncId>,
+    func_id: InputFuncId,
+}
+
+impl wasm_encoder::reencode::Reencode for FuncReencoder<'_> {
+    type Error = MissingFunctionMapping;
+
+    fn function_index(
+        &mut self,
+        func: u32,
+    ) -> Result<u32, wasm_encoder::reencode::Error<Self::Error>> {
+        self.dep_to_local_index
+            .get(&DepNode::Function(func as usize))
+            .copied()
+            .map(|i| i as u32)
+            .ok_or(wasm_encoder::reencode::Error::UserError(
+                MissingFunctionMapping {
+                    stub_func: self.func_id,
+                    referenced: func,
+                },
+            ))
     }
 }
 

--- a/crates/wasm_split_cli/src/lib.rs
+++ b/crates/wasm_split_cli/src/lib.rs
@@ -81,7 +81,7 @@ pub fn transform(opts: Options) -> Result<SplitWasm> {
         module.reloc_info.print_relocs();
     }
     // (2) dependency analysis and decide on splits
-    let dep_graph = dep_graph::get_dependencies(&module)?;
+    let (dep_graph, reloc_stub_fns) = dep_graph::get_dependencies(&module)?;
     let split_points = split_point::get_split_points(&module)?;
     let split_program_info = split_point::compute_split_modules(&module, &dep_graph, split_points)?;
 
@@ -92,7 +92,13 @@ pub fn transform(opts: Options) -> Result<SplitWasm> {
     }
     // (3) compute output modules and helper javascript
     let link_module = opts.link_name;
-    let emit_state = emit::EmitState::new(&opts, &module, &split_program_info, link_module)?;
+    let emit_state = emit::EmitState::new(
+        &opts,
+        &module,
+        &split_program_info,
+        link_module,
+        reloc_stub_fns,
+    )?;
     let wasm_modules = emit::emit_modules(
         &split_program_info,
         &emit_state,

--- a/crates/wasm_split_cli/tests/no_reloc_stub_end_to_end.rs
+++ b/crates/wasm_split_cli/tests/no_reloc_stub_end_to_end.rs
@@ -1,0 +1,301 @@
+//! Builds a minimal splittable wasm that contains a function whose `call`
+//! instruction has no covering `reloc.CODE` entry — the exact pattern
+//! wasm-ld synthesizes for LTO-merged wrapper stubs. Runs the full
+//! `wasm_split_cli_support::transform()` pipeline on it and asserts:
+//!
+//!   1. a pure call-forwarding `stub` (body = `call $helper; end`) gets
+//!      re-encoded, so its `call` immediate in the output points at
+//!      helper's remapped index (not the stale input-module index); and
+//!   2. a `dangerous_stub` (body = `global.get $g; drop; call $helper`)
+//!      is rejected by the warn list and falls through to the raw-copy
+//!      path — its `call` immediate in the output MUST stay at the
+//!      stale input index, because re-encoding it would silently emit
+//!      a stale `global.get` immediate (FuncReencoder only remaps
+//!      function indices).
+//!
+//! See #29.
+
+use std::borrow::Cow;
+
+use wasm_encoder::{
+    CodeSection, ConstExpr, CustomSection, ExportKind, ExportSection, Function, FunctionSection,
+    GlobalSection, GlobalType, ImportSection, Instruction, LinkingSection, MemorySection,
+    MemoryType, Module, RefType, SymbolTable, TableSection, TableType, TypeSection, ValType,
+};
+use wasmparser::{Operator, Parser, Payload, TypeRef};
+
+use wasm_split_cli_support::{transform, Options};
+
+/// Input layout (with 1 import): 0 = placeholder import, 1..=10 = padding,
+/// 11 = helper, 12 = stub, 13 = dangerous_stub, 14 = split_body, 15 = main.
+///
+/// Padding pushes helper to a HIGH input index so that a stale `call 11`
+/// in the output can never coincide with the remapped output index (the
+/// main output module only keeps a handful of defined funcs).
+const PAD: u32 = 10;
+const HELPER_IDX: u32 = 1 + PAD;
+const STUB_IDX: u32 = HELPER_IDX + 1;
+const DANGEROUS_STUB_IDX: u32 = STUB_IDX + 1;
+const SPLIT_BODY_IDX: u32 = DANGEROUS_STUB_IDX + 1;
+const MAIN_IDX: u32 = SPLIT_BODY_IDX + 1;
+
+/// Crucially there is **no `reloc.CODE` custom section**. That means
+/// every `call` instruction in defined functions has no reloc entry —
+/// the exact condition that used to miscompile before PR #29.
+fn build_input_wasm() -> Vec<u8> {
+    let mut module = Module::new();
+
+    let mut types = TypeSection::new();
+    types.ty().function([], []);
+    module.section(&types);
+
+    const SPLIT_NAME: &str = "testsplit";
+    const SPLIT_HASH: &str = "00000000000000000000000000000000";
+    let import_name = format!("__wasm_split_00{SPLIT_NAME}00_import_{SPLIT_HASH}");
+    let export_name = format!("__wasm_split_00{SPLIT_NAME}00_export_{SPLIT_HASH}");
+
+    let mut imports = ImportSection::new();
+    imports.import(
+        "__wasm_split_placeholder__",
+        &import_name,
+        wasm_encoder::EntityType::Function(0),
+    );
+    module.section(&imports);
+
+    let mut functions = FunctionSection::new();
+    for _ in 0..(PAD + 5) {
+        functions.function(0);
+    }
+    module.section(&functions);
+
+    let mut tables = TableSection::new();
+    tables.table(TableType {
+        element_type: RefType::FUNCREF,
+        minimum: 1,
+        maximum: Some(1),
+        table64: false,
+        shared: false,
+    });
+    module.section(&tables);
+
+    let mut memories = MemorySection::new();
+    memories.memory(MemoryType {
+        minimum: 1,
+        maximum: None,
+        memory64: false,
+        shared: false,
+        page_size_log2: None,
+    });
+    module.section(&memories);
+
+    // One i32 global, referenced by dangerous_stub's `global.get 0`.
+    let mut globals = GlobalSection::new();
+    globals.global(
+        GlobalType {
+            val_type: ValType::I32,
+            mutable: false,
+            shared: false,
+        },
+        &ConstExpr::i32_const(0),
+    );
+    module.section(&globals);
+
+    let mut exports = ExportSection::new();
+    exports.export(&export_name, ExportKind::Func, SPLIT_BODY_IDX);
+    exports.export("main", ExportKind::Func, MAIN_IDX);
+    exports.export("stub", ExportKind::Func, STUB_IDX);
+    exports.export("dangerous_stub", ExportKind::Func, DANGEROUS_STUB_IDX);
+    exports.export("helper", ExportKind::Func, HELPER_IDX);
+    exports.export("__indirect_function_table", ExportKind::Table, 0);
+    exports.export("memory", ExportKind::Memory, 0);
+    module.section(&exports);
+
+    let mut code = CodeSection::new();
+
+    // Padding: empty bodies, no calls → silently ignored by the classifier.
+    for _ in 0..PAD {
+        let mut pad = Function::new([]);
+        pad.instruction(&Instruction::End);
+        code.function(&pad);
+    }
+
+    // helper: empty body — not a stub (no `call` inside).
+    let mut helper = Function::new([]);
+    helper.instruction(&Instruction::End);
+    code.function(&helper);
+
+    // stub: pure `call $helper` + end. Classifier must detect this and
+    // re-encode it, rewriting the call immediate to helper's output idx.
+    let mut stub = Function::new([]);
+    stub.instruction(&Instruction::Call(HELPER_IDX));
+    stub.instruction(&Instruction::End);
+    code.function(&stub);
+
+    // dangerous_stub: `global.get 0; drop; call $helper`. The classifier
+    // must see `global.get` and refuse to treat this as a re-encodable
+    // stub (FuncReencoder only remaps function indices, not globals).
+    // It should fall through to the raw-copy emit path, preserving the
+    // body bytes verbatim — including the stale input `call $helper`
+    // immediate.
+    let mut dangerous = Function::new([]);
+    dangerous.instruction(&Instruction::GlobalGet(0));
+    dangerous.instruction(&Instruction::Drop);
+    dangerous.instruction(&Instruction::Call(HELPER_IDX));
+    dangerous.instruction(&Instruction::End);
+    code.function(&dangerous);
+
+    // split_body: reachable only from the split-point export, ends up in
+    // the split module.
+    let mut split_body = Function::new([]);
+    split_body.instruction(&Instruction::Call(HELPER_IDX));
+    split_body.instruction(&Instruction::End);
+    code.function(&split_body);
+
+    // main: keeps both stubs reachable in the main module.
+    let mut main = Function::new([]);
+    main.instruction(&Instruction::Call(STUB_IDX));
+    main.instruction(&Instruction::Call(DANGEROUS_STUB_IDX));
+    main.instruction(&Instruction::End);
+    code.function(&main);
+
+    module.section(&code);
+
+    let mut linking = LinkingSection::new();
+    let mut sym_tab = SymbolTable::new();
+    sym_tab.table(
+        SymbolTable::WASM_SYM_BINDING_LOCAL,
+        0,
+        Some("__indirect_function_table"),
+    );
+    linking.symbol_table(&sym_tab);
+    module.section(&linking);
+
+    // wasm-split marker: [tag u8][payload_len uleb][payload].
+    let ws_payload = [1u8, 1u8, 1u8];
+    module.section(&CustomSection {
+        name: Cow::Borrowed("__wasm_split_unstable"),
+        data: Cow::Borrowed(&ws_payload),
+    });
+
+    module.finish()
+}
+
+/// `(func_export_index, defined_func_index, import_count)`.
+fn locate_export(wasm: &[u8], export_name: &str) -> (u32, usize, usize) {
+    let mut import_count: usize = 0;
+    let mut target: Option<u32> = None;
+    for payload in Parser::new(0).parse_all(wasm) {
+        match payload.expect("valid wasm") {
+            Payload::ImportSection(reader) => {
+                for imp in reader {
+                    let imp = imp.expect("valid import");
+                    if matches!(imp.ty, TypeRef::Func(_)) {
+                        import_count += 1;
+                    }
+                }
+            }
+            Payload::ExportSection(reader) => {
+                for exp in reader {
+                    let exp = exp.expect("valid export");
+                    if exp.name == export_name {
+                        target = Some(exp.index);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    let idx = target.unwrap_or_else(|| panic!("export {export_name:?} not found"));
+    let defined = (idx as usize).checked_sub(import_count).unwrap_or_else(|| {
+        panic!(
+            "export {export_name:?} points at imported index {idx}, \
+             not a defined function (imports = {import_count})"
+        )
+    });
+    (idx, defined, import_count)
+}
+
+/// Returns the first `Call`'s `function_index` immediate from a body.
+fn first_call_immediate(body: &wasmparser::FunctionBody<'_>) -> u32 {
+    let mut reader = body.get_operators_reader().expect("operators");
+    while !reader.eof() {
+        if let Operator::Call { function_index } = reader.read().expect("op") {
+            return function_index;
+        }
+    }
+    panic!("body contained no Call operator");
+}
+
+fn nth_defined_body<'a>(wasm: &'a [u8], nth: usize) -> wasmparser::FunctionBody<'a> {
+    Parser::new(0)
+        .parse_all(wasm)
+        .filter_map(|p| match p.expect("valid wasm") {
+            Payload::CodeSectionEntry(body) => Some(body),
+            _ => None,
+        })
+        .nth(nth)
+        .unwrap_or_else(|| panic!("module has fewer than {} defined functions", nth + 1))
+}
+
+#[test]
+fn no_reloc_stub_is_rewritten_and_dangerous_stub_is_raw_copied() {
+    let input = build_input_wasm();
+
+    // Sanity: input should parse as a wasm module.
+    for payload in Parser::new(0).parse_all(&input) {
+        payload.expect("input wasm is valid");
+    }
+
+    let tmp = std::env::temp_dir().join(format!(
+        "wasm_split_no_reloc_test_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&tmp).expect("create tmpdir");
+    let main_out = tmp.join("main.wasm");
+
+    let mut opts = Options::new(&input);
+    opts.output_dir = &tmp;
+    opts.main_out_path = &main_out;
+    opts.link_name = "./__wasm_split.js";
+    opts.main_module = "./main.js";
+
+    transform(opts).expect("transform succeeds");
+
+    let main_bytes = std::fs::read(&main_out).expect("read main.wasm output");
+
+    let (helper_func_idx, _, _) = locate_export(&main_bytes, "helper");
+    let (_, stub_defined_idx, _) = locate_export(&main_bytes, "stub");
+    let (_, dangerous_defined_idx, _) = locate_export(&main_bytes, "dangerous_stub");
+
+    // --- Assertion 1: pure stub's call was remapped.
+    let stub_call = first_call_immediate(&nth_defined_body(&main_bytes, stub_defined_idx));
+    assert_eq!(
+        stub_call, helper_func_idx,
+        "pure stub should have its `call` immediate remapped to helper's \
+         output index {helper_func_idx}, got {stub_call} — PR #29 remap regressed?",
+    );
+
+    // --- Assertion 2: dangerous stub was raw-copied (NOT re-encoded).
+    // A stale input immediate is the signal that the warn list rejected
+    // the classification and the body went through raw-copy. Commenting
+    // out the warn list flips this: the dangerous stub gets re-encoded
+    // and the call is rewritten to `helper_func_idx` — silently emitting
+    // a stale `global.get` immediate in the process.
+    let dangerous_call =
+        first_call_immediate(&nth_defined_body(&main_bytes, dangerous_defined_idx));
+
+    assert_eq!(
+        dangerous_call, HELPER_IDX,
+        "dangerous stub (with global.get) must be raw-copied, so its \
+         `call` immediate stays at the stale input index {HELPER_IDX}. \
+         Got {dangerous_call} — warn-list regressed and the body went \
+         through the re-encoder, which would also silently mis-emit the \
+         global.get immediate.",
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/crates/wasm_split_cli/tests/no_reloc_stub_end_to_end.rs
+++ b/crates/wasm_split_cli/tests/no_reloc_stub_end_to_end.rs
@@ -246,6 +246,8 @@ fn nth_defined_body<'a>(wasm: &'a [u8], nth: usize) -> wasmparser::FunctionBody<
 
 #[test]
 fn no_reloc_stub_is_rewritten_and_dangerous_stub_is_raw_copied() {
+    tracing_subscriber::fmt::init();
+
     let input = build_input_wasm();
 
     // Sanity: input should parse as a wasm module.

--- a/crates/wasm_split_cli/tests/no_reloc_stub_end_to_end.rs
+++ b/crates/wasm_split_cli/tests/no_reloc_stub_end_to_end.rs
@@ -1,15 +1,15 @@
 //! Builds a minimal splittable wasm that contains a function whose `call`
-//! instruction has no covering `reloc.CODE` entry — the exact pattern
-//! wasm-ld synthesizes for LTO-merged wrapper stubs. Runs the full
+//! instruction has no covering `reloc.CODE` entry - a pattern
+//! wasm-ld synthesizes for LTO-merged wrapper stubs. Then runs the full
 //! `wasm_split_cli_support::transform()` pipeline on it and asserts:
 //!
-//!   1. a pure call-forwarding `stub` (body = `call $helper; end`) gets
+//!   1. a pure call-forwarding `stub` (body = `(call $helper)`) gets
 //!      re-encoded, so its `call` immediate in the output points at
 //!      helper's remapped index (not the stale input-module index); and
-//!   2. a `dangerous_stub` (body = `global.get $g; drop; call $helper`)
-//!      is rejected by the warn list and falls through to the raw-copy
-//!      path — its `call` immediate in the output MUST stay at the
-//!      stale input index, because re-encoding it would silently emit
+//!   2. a `dangerous_stub` (body = `(global.get $g drop call $helper)`)
+//!      falls through to the raw-copy path - its `call` immediate in
+//!      the output SHOULD stay at the stale input index.
+//!      Re-encoding it should emit a warning, to not silently emit
 //!      a stale `global.get` immediate (FuncReencoder only remaps
 //!      function indices).
 //!
@@ -33,14 +33,20 @@ use wasm_split_cli_support::{transform, Options};
 /// in the output can never coincide with the remapped output index (the
 /// main output module only keeps a handful of defined funcs).
 const PAD: u32 = 10;
-const HELPER_IDX: u32 = 1 + PAD;
+const HELPER_IDX: u32 = PAD + 1;
+const HELPER_EXPORT: &str = "helper";
 const STUB_IDX: u32 = HELPER_IDX + 1;
+const STUB_EXPORT: &str = "stub";
 const DANGEROUS_STUB_IDX: u32 = STUB_IDX + 1;
+const DANGEROUS_STUB_EXPORT: &str = "dangerous_stub";
 const SPLIT_BODY_IDX: u32 = DANGEROUS_STUB_IDX + 1;
 const MAIN_IDX: u32 = SPLIT_BODY_IDX + 1;
 
+#[path = "../src/magic_constants.rs"]
+mod magic_constants;
+
 /// Crucially there is **no `reloc.CODE` custom section**. That means
-/// every `call` instruction in defined functions has no reloc entry —
+/// every `call` instruction in defined functions has no reloc entry -
 /// the exact condition that used to miscompile before PR #29.
 fn build_input_wasm() -> Vec<u8> {
     let mut module = Module::new();
@@ -56,14 +62,14 @@ fn build_input_wasm() -> Vec<u8> {
 
     let mut imports = ImportSection::new();
     imports.import(
-        "__wasm_split_placeholder__",
+        magic_constants::PLACEHOLDER_IMPORT_MODULE,
         &import_name,
         wasm_encoder::EntityType::Function(0),
     );
     module.section(&imports);
 
     let mut functions = FunctionSection::new();
-    for _ in 0..(PAD + 5) {
+    for _ in 1..=MAIN_IDX {
         functions.function(0);
     }
     module.section(&functions);
@@ -103,9 +109,9 @@ fn build_input_wasm() -> Vec<u8> {
     let mut exports = ExportSection::new();
     exports.export(&export_name, ExportKind::Func, SPLIT_BODY_IDX);
     exports.export("main", ExportKind::Func, MAIN_IDX);
-    exports.export("stub", ExportKind::Func, STUB_IDX);
-    exports.export("dangerous_stub", ExportKind::Func, DANGEROUS_STUB_IDX);
-    exports.export("helper", ExportKind::Func, HELPER_IDX);
+    exports.export(STUB_EXPORT, ExportKind::Func, STUB_IDX);
+    exports.export(DANGEROUS_STUB_EXPORT, ExportKind::Func, DANGEROUS_STUB_IDX);
+    exports.export(HELPER_EXPORT, ExportKind::Func, HELPER_IDX);
     exports.export("__indirect_function_table", ExportKind::Table, 0);
     exports.export("memory", ExportKind::Memory, 0);
     module.section(&exports);
@@ -119,7 +125,7 @@ fn build_input_wasm() -> Vec<u8> {
         code.function(&pad);
     }
 
-    // helper: empty body — not a stub (no `call` inside).
+    // helper: empty body - not a stub (no `call` inside).
     let mut helper = Function::new([]);
     helper.instruction(&Instruction::End);
     code.function(&helper);
@@ -135,7 +141,7 @@ fn build_input_wasm() -> Vec<u8> {
     // must see `global.get` and refuse to treat this as a re-encodable
     // stub (FuncReencoder only remaps function indices, not globals).
     // It should fall through to the raw-copy emit path, preserving the
-    // body bytes verbatim — including the stale input `call $helper`
+    // body bytes verbatim - including the stale input `call $helper`
     // immediate.
     let mut dangerous = Function::new([]);
     dangerous.instruction(&Instruction::GlobalGet(0));
@@ -170,18 +176,18 @@ fn build_input_wasm() -> Vec<u8> {
     linking.symbol_table(&sym_tab);
     module.section(&linking);
 
-    // wasm-split marker: [tag u8][payload_len uleb][payload].
+    // wasm-split marker: [tag u8][payload_len uleb][payload]. (see wasm_split/../marker.rs)
     let ws_payload = [1u8, 1u8, 1u8];
     module.section(&CustomSection {
-        name: Cow::Borrowed("__wasm_split_unstable"),
+        name: Cow::Borrowed(magic_constants::LINK_SECTION),
         data: Cow::Borrowed(&ws_payload),
     });
 
     module.finish()
 }
 
-/// `(func_export_index, defined_func_index, import_count)`.
-fn locate_export(wasm: &[u8], export_name: &str) -> (u32, usize, usize) {
+/// `(func_export_index, defined_func_index)`.
+fn locate_export(wasm: &[u8], export_name: &str) -> (u32, usize) {
     let mut import_count: usize = 0;
     let mut target: Option<u32> = None;
     for payload in Parser::new(0).parse_all(wasm) {
@@ -199,6 +205,7 @@ fn locate_export(wasm: &[u8], export_name: &str) -> (u32, usize, usize) {
                     let exp = exp.expect("valid export");
                     if exp.name == export_name {
                         target = Some(exp.index);
+                        break;
                     }
                 }
             }
@@ -212,7 +219,7 @@ fn locate_export(wasm: &[u8], export_name: &str) -> (u32, usize, usize) {
              not a defined function (imports = {import_count})"
         )
     });
-    (idx, defined, import_count)
+    (idx, defined)
 }
 
 /// Returns the first `Call`'s `function_index` immediate from a body.
@@ -246,56 +253,47 @@ fn no_reloc_stub_is_rewritten_and_dangerous_stub_is_raw_copied() {
         payload.expect("input wasm is valid");
     }
 
-    let tmp = std::env::temp_dir().join(format!(
-        "wasm_split_no_reloc_test_{}_{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&tmp).expect("create tmpdir");
-    let main_out = tmp.join("main.wasm");
+    let mut tmp = tempfile::tempdir().expect("create tmpdir");
+    tmp.disable_cleanup(true);
+    let main_out = tmp.path().join("main.wasm");
 
     let mut opts = Options::new(&input);
-    opts.output_dir = &tmp;
+    opts.output_dir = tmp.path();
     opts.main_out_path = &main_out;
-    opts.link_name = "./__wasm_split.js";
-    opts.main_module = "./main.js";
 
     transform(opts).expect("transform succeeds");
 
     let main_bytes = std::fs::read(&main_out).expect("read main.wasm output");
 
-    let (helper_func_idx, _, _) = locate_export(&main_bytes, "helper");
-    let (_, stub_defined_idx, _) = locate_export(&main_bytes, "stub");
-    let (_, dangerous_defined_idx, _) = locate_export(&main_bytes, "dangerous_stub");
+    let (helper_func_idx, _) = locate_export(&main_bytes, HELPER_EXPORT);
+    let (_, stub_defined_idx) = locate_export(&main_bytes, STUB_EXPORT);
+    let (_, dangerous_defined_idx) = locate_export(&main_bytes, DANGEROUS_STUB_EXPORT);
 
     // --- Assertion 1: pure stub's call was remapped.
     let stub_call = first_call_immediate(&nth_defined_body(&main_bytes, stub_defined_idx));
     assert_eq!(
         stub_call, helper_func_idx,
         "pure stub should have its `call` immediate remapped to helper's \
-         output index {helper_func_idx}, got {stub_call} — PR #29 remap regressed?",
+         output index {helper_func_idx}, got {stub_call} - PR #29 remap regressed?",
     );
 
     // --- Assertion 2: dangerous stub was raw-copied (NOT re-encoded).
     // A stale input immediate is the signal that the warn list rejected
     // the classification and the body went through raw-copy. Commenting
     // out the warn list flips this: the dangerous stub gets re-encoded
-    // and the call is rewritten to `helper_func_idx` — silently emitting
+    // and the call is rewritten to `helper_func_idx` - silently emitting
     // a stale `global.get` immediate in the process.
     let dangerous_call =
         first_call_immediate(&nth_defined_body(&main_bytes, dangerous_defined_idx));
 
     assert_eq!(
         dangerous_call, HELPER_IDX,
-        "dangerous stub (with global.get) must be raw-copied, so its \
+        "dangerous stub (with global.get) should be raw-copied, so its \
          `call` immediate stays at the stale input index {HELPER_IDX}. \
-         Got {dangerous_call} — warn-list regressed and the body went \
+         Got {dangerous_call} - warn-list regressed and the body went \
          through the re-encoder, which would also silently mis-emit the \
          global.get immediate.",
     );
 
-    let _ = std::fs::remove_dir_all(&tmp);
+    tmp.disable_cleanup(false);
 }


### PR DESCRIPTION
See #29 