### PR TITLE
Retry failed split-module loads instead of caching the failure forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 - A failed split-module load is no longer cached for the lifetime of the session
   (one transient network failure used to permanently break the module — see
-  #35). Two layers cooperate: the generated JS loader retries the fetch itself a
-  few times with a short backoff (handling brief network blips), and on the Rust
-  side the loader now uses `async_once_cell::OnceCell` instead of `Lazy`, so a
-  load that still fails leaves the cell uninitialized rather than memoizing the
-  failure — a later `ensure_loaded` (e.g. on the next navigation) starts a fresh
-  attempt. A hard failure that survives the JS retries still panics (the load is
-  infallible from the caller's perspective), but the panic is no longer
-  permanent for the session. `makeLoad` now memoizes only successful loads.
+  #35). On the Rust side the loader now uses `async_once_cell::OnceCell` instead
+  of `Lazy`, so a load that fails leaves the cell uninitialized rather than
+  memoizing the failure, and `makeLoad` likewise memoizes only successful loads —
+  a later load attempt (e.g. on the next navigation) starts fresh. Recovery is
+  driven by the caller rather than forced retries: `ensure_loaded` now returns
+  `Result<(), SplitLoaderError>`, and `#[wasm_split(..)]` gains a `fallible`
+  option that makes the generated wrapper return
+  `Result<_, SplitLoaderError>` and propagate the load error instead of
+  panicking (a panic aborts the whole wasm module). The generated `preload`
+  function returns the same `Result`. Without `fallible` the wrapper still
+  `.expect()`s a successful load, preserving the previous behavior.
 
 ## wasm_split_helpers v0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 ## Unreleased
 
 - A failed split-module load is no longer cached for the lifetime of the session
-  (one transient network failure used to permanently break the module and panic
-  the runtime — see #35). The JS loader now retries transient fetch failures
-  with a short backoff and only memoizes successful loads; `ensure_loaded`
-  re-invokes the load function after a failed callback (bounded per call) and
-  resets the loader state on failure so later calls always start fresh.
+  (one transient network failure used to permanently break the module — see
+  #35). Two layers cooperate: the generated JS loader retries the fetch itself a
+  few times with a short backoff (handling brief network blips), and on the Rust
+  side the loader now uses `async_once_cell::OnceCell` instead of `Lazy`, so a
+  load that still fails leaves the cell uninitialized rather than memoizing the
+  failure — a later `ensure_loaded` (e.g. on the next navigation) starts a fresh
+  attempt. A hard failure that survives the JS retries still panics (the load is
+  infallible from the caller's perspective), but the panic is no longer
+  permanent for the session. `makeLoad` now memoizes only successful loads.
 
 ## wasm_split_helpers v0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,12 @@
 ## Unreleased
 
 - A failed split-module load is no longer cached for the lifetime of the session
-  (one transient network failure used to permanently break the module — see
-  #35). On the Rust side the loader now uses `async_once_cell::OnceCell` instead
-  of `Lazy`, so a load that fails leaves the cell uninitialized rather than
-  memoizing the failure, and `makeLoad` likewise memoizes only successful loads —
-  a later load attempt (e.g. on the next navigation) starts fresh. Recovery is
-  driven by the caller rather than forced retries: `ensure_loaded` now returns
-  `Result<(), SplitLoaderError>`, and `#[wasm_split(..)]` gains a `fallible`
-  option that makes the generated wrapper return
-  `Result<_, SplitLoaderError>` and propagate the load error instead of
-  panicking (a panic aborts the whole wasm module). The generated `preload`
-  function returns the same `Result`. Without `fallible` the wrapper still
-  `.expect()`s a successful load, preserving the previous behavior.
+  (one transient network failure used to permanently break the module; see #35).
+  Only successful loads are now memoized, so a later load attempt starts fresh.
+  `ensure_loaded` returns `Result<(), SplitLoaderError>`, and `#[wasm_split(..)]`
+  gains a `fallible` option that makes the generated wrapper return the load
+  error instead of panicking. Without `fallible` the wrapper still expects a
+  successful load, as before.
 
 ## wasm_split_helpers v0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
   (one transient network failure used to permanently break the module; see #35).
   Only successful loads are now memoized, so a later load attempt starts fresh.
   `ensure_loaded` returns `Result<(), SplitLoaderError>`, and `#[wasm_split(..)]`
-  gains a `fallible` option that makes the generated wrapper return the load
-  error instead of panicking. Without `fallible` the wrapper still expects a
-  successful load, as before.
+  gains a `fallible` option that makes the generated wrapper (and its `preload`)
+  return the load error instead of panicking. Without `fallible` the wrapper and
+  `preload` keep their previous infallible signatures and a hard failure panics,
+  as before.
 
 ## wasm_split_helpers v0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+- A failed split-module load is no longer cached for the lifetime of the session
+  (one transient network failure used to permanently break the module and panic
+  the runtime — see #35). The JS loader now retries transient fetch failures
+  with a short backoff and only memoizes successful loads; `ensure_loaded`
+  re-invokes the load function after a failed callback (bounded per call) and
+  resets the loader state on failure so later calls always start fresh.
+
 ## wasm_split_helpers v0.2.1
 
 - Improved resilience against multiple versions of the lib being included, mainly working around akward usage of `#[link_section]`

--- a/crates/wasm_split/src/lib.rs
+++ b/crates/wasm_split/src/lib.rs
@@ -22,6 +22,10 @@
 
 pub use wasm_split_macros::wasm_split;
 
+/// The error returned by a `fallible` split function (and `preload`) when its
+/// module fails to load.
+pub use rt::SplitLoaderError;
+
 #[doc(hidden)]
 pub mod rt;
 

--- a/crates/wasm_split/src/rt.rs
+++ b/crates/wasm_split/src/rt.rs
@@ -9,104 +9,229 @@ use std::{
 pub type LoadCallbackFn = unsafe extern "C" fn(*const c_void, bool) -> ();
 pub type LoadFn = unsafe extern "C" fn(LoadCallbackFn, *const c_void) -> ();
 
-type Lazy = async_once_cell::Lazy<Option<()>, SplitLoaderFuture>;
+/// How many times a single `ensure_loaded` call re-invokes the load function
+/// after a failed attempt before giving up. A failed attempt also resets the
+/// loader to its unloaded state, so *later* `ensure_loaded` calls start fresh
+/// attempts even after one call exhausted its budget — a transient network
+/// failure no longer bricks the split module for the lifetime of the session.
+const MAX_ATTEMPTS_PER_CALL: usize = 3;
 
 pub struct LazySplitLoader {
-    lazy: Lazy,
+    load: LoadFn,
+    state: Mutex<LoadState>,
+}
+
+enum LoadState {
+    /// No load attempt is running (initial state, and the state after a
+    /// failed attempt has been observed).
+    NotStarted,
+    /// A load attempt is in flight; all concurrent waiters share it.
+    InFlight(Arc<SplitLoader>),
+    /// The module loaded successfully. Terminal.
+    Ready,
 }
 
 impl LazySplitLoader {
     /// # Safety
     /// The load function must be safely callable with a callback-fn-pointer and data.
-    /// It must call the callback function exactly once with the given data and a success state.
+    /// It must call the callback function exactly once per invocation with the
+    /// given data and a success state.
     pub const unsafe fn new(load: LoadFn) -> Self {
         Self {
-            lazy: Lazy::new(SplitLoaderFuture::new(load)),
+            load,
+            state: Mutex::new(LoadState::NotStarted),
         }
     }
 }
 
 pub async fn ensure_loaded(loader: Pin<&LazySplitLoader>) {
-    // SAFETY: this is just pin projection
-    let inner = unsafe { Pin::new_unchecked(&loader.lazy) };
-    inner.await.expect("load callback should succeed");
-}
-
-enum SplitLoaderFutState {
-    Deferred(LoadFn),
-    Pending(Arc<SplitLoader>),
-}
-
-struct SplitLoaderFuture {
-    state: SplitLoaderFutState,
-}
-
-impl SplitLoaderFuture {
-    const fn new(load: LoadFn) -> Self {
-        SplitLoaderFuture {
-            state: SplitLoaderFutState::Deferred(load),
-        }
-    }
-}
-
-impl Future for SplitLoaderFuture {
-    type Output = Option<()>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<()>> {
-        match self.state {
-            SplitLoaderFutState::Deferred(load) => {
-                let shared_state = Arc::new(SplitLoader {
-                    state: Mutex::new(SplitLoaderState::Waiting(cx.waker().clone())),
-                });
-                unsafe {
-                    load(
-                        load_callback,
-                        Arc::<SplitLoader>::into_raw(shared_state.clone()).cast(),
-                    )
-                };
-                self.state = SplitLoaderFutState::Pending(shared_state);
-                Poll::Pending
-            }
-            SplitLoaderFutState::Pending(ref state) => state.update(|state| match state {
-                SplitLoaderState::Done(value) => Poll::Ready(value.then_some(())),
-                SplitLoaderState::Waiting(ref mut waker) => {
-                    *waker = cx.waker().clone();
-                    Poll::Pending
+    let loader = loader.get_ref();
+    let mut attempts = 0;
+    loop {
+        // Join the in-flight attempt, or start a new one.
+        let attempt = {
+            let mut state = loader.state.lock().expect("lock poisoned");
+            match &*state {
+                LoadState::Ready => return,
+                LoadState::InFlight(shared) => shared.clone(),
+                LoadState::NotStarted => {
+                    let shared = Arc::new(SplitLoader::new());
+                    // SAFETY: upheld by the caller of `LazySplitLoader::new`.
+                    unsafe { (loader.load)(load_callback, Arc::into_raw(shared.clone()).cast()) };
+                    *state = LoadState::InFlight(shared.clone());
+                    shared
                 }
-            }),
+            }
+        };
+
+        attempts += 1;
+        let success = SplitLoaderFuture {
+            shared: attempt.clone(),
+        }
+        .await;
+
+        let mut state = loader.state.lock().expect("lock poisoned");
+        if success {
+            *state = LoadState::Ready;
+            return;
+        }
+        // The attempt failed. Reset to NotStarted so the next iteration (or a
+        // later `ensure_loaded` call) starts a fresh attempt — but only if the
+        // recorded attempt is still ours; a concurrent waiter may have reset
+        // and restarted already, in which case we join that attempt instead.
+        if let LoadState::InFlight(current) = &*state {
+            if Arc::ptr_eq(current, &attempt) {
+                *state = LoadState::NotStarted;
+            }
+        }
+        drop(state);
+
+        if attempts >= MAX_ATTEMPTS_PER_CALL {
+            // Give up on *this* call. The loader state is already reset, so
+            // future calls still retry.
+            panic!("load callback should succeed");
         }
     }
 }
-
-// our future should never get canceled before completion. We could assert this?
-// impl Drop for SplitLoaderFuture { }
 
 unsafe extern "C" fn load_callback(loader: *const c_void, success: bool) {
     // SAFETY: The pointer is the same as the one passed to `load`, hence comes from a call to Arc::into_raw
     unsafe { Arc::<SplitLoader>::from_raw(loader.cast()) }.complete(success);
 }
 
+/// One load attempt: completed exactly once by `load_callback`, awaited by any
+/// number of concurrent `ensure_loaded` callers.
 struct SplitLoader {
     state: Mutex<SplitLoaderState>,
 }
 
+enum SplitLoaderState {
+    Pending(Vec<Waker>),
+    Done(bool),
+}
+
 impl SplitLoader {
-    fn update<R>(&self, f: impl FnOnce(&mut SplitLoaderState) -> R) -> R {
-        let mut state = self.state.lock().expect("lock poisoned");
-        f(&mut state)
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(SplitLoaderState::Pending(Vec::new())),
+        }
     }
+
     fn complete(&self, value: bool) {
-        self.update(|state| {
-            if let SplitLoaderState::Waiting(waker) =
-                std::mem::replace(state, SplitLoaderState::Done(value))
-            {
-                waker.wake();
+        let wakers = {
+            let mut state = self.state.lock().expect("lock poisoned");
+            match std::mem::replace(&mut *state, SplitLoaderState::Done(value)) {
+                SplitLoaderState::Pending(wakers) => wakers,
+                // The load function's contract is one callback per invocation;
+                // tolerate a duplicate rather than corrupting state.
+                SplitLoaderState::Done(_) => Vec::new(),
             }
-        });
+        };
+        for waker in wakers {
+            waker.wake();
+        }
     }
 }
 
-enum SplitLoaderState {
-    Waiting(Waker),
-    Done(bool),
+struct SplitLoaderFuture {
+    shared: Arc<SplitLoader>,
+}
+
+impl Future for SplitLoaderFuture {
+    type Output = bool;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<bool> {
+        let mut state = self.shared.state.lock().expect("lock poisoned");
+        match &mut *state {
+            SplitLoaderState::Done(value) => Poll::Ready(*value),
+            SplitLoaderState::Pending(wakers) => {
+                if !wakers.iter().any(|w| w.will_wake(cx.waker())) {
+                    wakers.push(cx.waker().clone());
+                }
+                Poll::Pending
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{RawWaker, RawWakerVTable};
+
+    // Drive a future to completion with a no-op waker. The test load fns
+    // complete synchronously inside `load`, so polling in a loop suffices.
+    fn block_on<F: Future>(fut: F) -> F::Output {
+        fn noop_raw_waker() -> RawWaker {
+            fn no_op(_: *const ()) {}
+            fn clone(_: *const ()) -> RawWaker {
+                noop_raw_waker()
+            }
+            static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, no_op, no_op, no_op);
+            RawWaker::new(std::ptr::null(), &VTABLE)
+        }
+        let waker = unsafe { Waker::from_raw(noop_raw_waker()) };
+        let mut cx = Context::from_waker(&waker);
+        let mut fut = std::pin::pin!(fut);
+        for _ in 0..1000 {
+            if let Poll::Ready(out) = fut.as_mut().poll(&mut cx) {
+                return out;
+            }
+        }
+        panic!("future did not complete");
+    }
+
+    // The scripted load fn shares these statics, so tests must not interleave.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+    static CALLS: AtomicUsize = AtomicUsize::new(0);
+    static SUCCEED_FROM_CALL: AtomicUsize = AtomicUsize::new(0);
+
+    unsafe extern "C" fn scripted_load(cb: LoadCallbackFn, data: *const c_void) {
+        let call = CALLS.fetch_add(1, Ordering::SeqCst) + 1;
+        let success = call >= SUCCEED_FROM_CALL.load(Ordering::SeqCst);
+        unsafe { cb(data, success) };
+    }
+
+    fn reset_script(succeed_from_call: usize) {
+        CALLS.store(0, Ordering::SeqCst);
+        SUCCEED_FROM_CALL.store(succeed_from_call, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn retries_within_one_call_until_success() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_script(3); // fail, fail, succeed
+        let loader = unsafe { LazySplitLoader::new(scripted_load) };
+        block_on(ensure_loaded(Pin::new(&loader)));
+        assert_eq!(CALLS.load(Ordering::SeqCst), 3);
+        // Once Ready, no further load invocations.
+        block_on(ensure_loaded(Pin::new(&loader)));
+        assert_eq!(CALLS.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn later_call_retries_after_exhausted_call() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_script(MAX_ATTEMPTS_PER_CALL + 1); // first call exhausts its budget
+        let loader = unsafe { LazySplitLoader::new(scripted_load) };
+        let exhausted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            block_on(ensure_loaded(Pin::new(&loader)));
+        }));
+        assert!(exhausted.is_err(), "first call should give up");
+        assert_eq!(CALLS.load(Ordering::SeqCst), MAX_ATTEMPTS_PER_CALL);
+        // The failure must NOT be cached: a later call starts fresh and succeeds.
+        block_on(ensure_loaded(Pin::new(&loader)));
+        assert_eq!(CALLS.load(Ordering::SeqCst), MAX_ATTEMPTS_PER_CALL + 1);
+    }
+
+    #[test]
+    fn immediate_success_loads_once() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_script(1);
+        let loader = unsafe { LazySplitLoader::new(scripted_load) };
+        block_on(ensure_loaded(Pin::new(&loader)));
+        block_on(ensure_loaded(Pin::new(&loader)));
+        assert_eq!(CALLS.load(Ordering::SeqCst), 1);
+    }
 }

--- a/crates/wasm_split/src/rt.rs
+++ b/crates/wasm_split/src/rt.rs
@@ -6,91 +6,57 @@ use std::{
     task::{Context, Poll, Waker},
 };
 
+use async_once_cell::OnceCell;
+
 pub type LoadCallbackFn = unsafe extern "C" fn(*const c_void, bool) -> ();
 pub type LoadFn = unsafe extern "C" fn(LoadCallbackFn, *const c_void) -> ();
 
-/// How many times a single `ensure_loaded` call re-invokes the load function
-/// after a failed attempt before giving up. A failed attempt also resets the
-/// loader to its unloaded state, so *later* `ensure_loaded` calls start fresh
-/// attempts even after one call exhausted its budget — a transient network
-/// failure no longer bricks the split module for the lifetime of the session.
-const MAX_ATTEMPTS_PER_CALL: usize = 3;
-
+/// Loads a split module on demand.
+///
+/// Backed by [`async_once_cell::OnceCell`]: a *successful* load is memoized so
+/// the module is only ever loaded once, but a *failed* load leaves the cell
+/// uninitialized, so a later `ensure_loaded` call retries from scratch. This is
+/// what prevents a single transient load failure (flaky network, aborted
+/// request) from bricking the split module for the lifetime of the session —
+/// the generated JS loader additionally retries the fetch itself with backoff,
+/// so reaching a hard failure here is rare. See CHANGELOG / issue #35.
 pub struct LazySplitLoader {
     load: LoadFn,
-    state: Mutex<LoadState>,
-}
-
-enum LoadState {
-    /// No load attempt is running (initial state, and the state after a
-    /// failed attempt has been observed).
-    NotStarted,
-    /// A load attempt is in flight; all concurrent waiters share it.
-    InFlight(Arc<SplitLoader>),
-    /// The module loaded successfully. Terminal.
-    Ready,
+    cell: OnceCell<()>,
 }
 
 impl LazySplitLoader {
     /// # Safety
     /// The load function must be safely callable with a callback-fn-pointer and data.
-    /// It must call the callback function exactly once per invocation with the
-    /// given data and a success state.
+    /// It must call the callback function exactly once per invocation with the given
+    /// data and a success state. (It may be invoked more than once across retries,
+    /// each invocation calling back exactly once.)
     pub const unsafe fn new(load: LoadFn) -> Self {
         Self {
             load,
-            state: Mutex::new(LoadState::NotStarted),
+            cell: OnceCell::new(),
         }
     }
 }
 
 pub async fn ensure_loaded(loader: Pin<&LazySplitLoader>) {
+    // SAFETY: pin projection; `LazySplitLoader` is never moved out of.
     let loader = loader.get_ref();
-    let mut attempts = 0;
-    loop {
-        // Join the in-flight attempt, or start a new one.
-        let attempt = {
-            let mut state = loader.state.lock().expect("lock poisoned");
-            match &*state {
-                LoadState::Ready => return,
-                LoadState::InFlight(shared) => shared.clone(),
-                LoadState::NotStarted => {
-                    let shared = Arc::new(SplitLoader::new());
-                    // SAFETY: upheld by the caller of `LazySplitLoader::new`.
-                    unsafe { (loader.load)(load_callback, Arc::into_raw(shared.clone()).cast()) };
-                    *state = LoadState::InFlight(shared.clone());
-                    shared
-                }
-            }
-        };
-
-        attempts += 1;
-        let success = SplitLoaderFuture {
-            shared: attempt.clone(),
-        }
+    // `OnceCell` runs the init future once, serializing concurrent callers onto
+    // a single in-flight attempt and waking them all when it settles. On `Err`
+    // the cell stays empty, so a subsequent `ensure_loaded` starts a fresh
+    // attempt rather than caching the failure.
+    let result = loader
+        .cell
+        .get_or_try_init(SplitLoaderFuture::new(loader.load))
         .await;
-
-        let mut state = loader.state.lock().expect("lock poisoned");
-        if success {
-            *state = LoadState::Ready;
-            return;
-        }
-        // The attempt failed. Reset to NotStarted so the next iteration (or a
-        // later `ensure_loaded` call) starts a fresh attempt — but only if the
-        // recorded attempt is still ours; a concurrent waiter may have reset
-        // and restarted already, in which case we join that attempt instead.
-        if let LoadState::InFlight(current) = &*state {
-            if Arc::ptr_eq(current, &attempt) {
-                *state = LoadState::NotStarted;
-            }
-        }
-        drop(state);
-
-        if attempts >= MAX_ATTEMPTS_PER_CALL {
-            // Give up on *this* call. The loader state is already reset, so
-            // future calls still retry.
-            panic!("load callback should succeed");
-        }
+    if result.is_err() {
+        // The load contract is infallible from the caller's side (the generated
+        // code treats split modules as must-load), so a hard failure that even
+        // the JS-side fetch retries couldn't recover panics — but unlike the
+        // previous implementation it is NOT cached, so reloading / a later
+        // navigation can succeed.
+        panic!("load callback should succeed");
     }
 }
 
@@ -99,57 +65,102 @@ unsafe extern "C" fn load_callback(loader: *const c_void, success: bool) {
     unsafe { Arc::<SplitLoader>::from_raw(loader.cast()) }.complete(success);
 }
 
-/// One load attempt: completed exactly once by `load_callback`, awaited by any
-/// number of concurrent `ensure_loaded` callers.
+/// Bridges the FFI callback into a `Future`. One instance exists per load
+/// attempt and is polled by exactly one task (`OnceCell` serializes init), so a
+/// single optional waker suffices — there is no need to track multiple waiters
+/// here. Resolves `Ok(())` on success and `Err(())` on failure.
+struct SplitLoaderFuture {
+    load: LoadFn,
+    shared: Option<Arc<SplitLoader>>,
+}
+
+impl SplitLoaderFuture {
+    fn new(load: LoadFn) -> Self {
+        Self { load, shared: None }
+    }
+}
+
+impl Future for SplitLoaderFuture {
+    type Output = Result<(), ()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), ()>> {
+        match &self.shared {
+            // First poll: kick off the load. The callback (sync or async) drives
+            // `complete`. Not under any lock, so a synchronous callback is fine.
+            None => {
+                let shared = Arc::new(SplitLoader {
+                    state: Mutex::new(SplitLoaderState::Pending(Some(cx.waker().clone()))),
+                });
+                // SAFETY: contract upheld by the caller of `LazySplitLoader::new`;
+                // the matching `from_raw` happens in `load_callback`.
+                unsafe {
+                    (self.load)(
+                        load_callback,
+                        Arc::<SplitLoader>::into_raw(shared.clone()).cast(),
+                    )
+                };
+                // A synchronous callback may already have marked it Done.
+                let done = shared.state.lock().expect("lock poisoned").done_value();
+                self.shared = Some(shared);
+                match done {
+                    Some(success) => Poll::Ready(ok_or_err(success)),
+                    None => Poll::Pending,
+                }
+            }
+            Some(shared) => {
+                let mut state = shared.state.lock().expect("lock poisoned");
+                match &mut *state {
+                    SplitLoaderState::Done(success) => Poll::Ready(ok_or_err(*success)),
+                    SplitLoaderState::Pending(waker) => {
+                        *waker = Some(cx.waker().clone());
+                        Poll::Pending
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn ok_or_err(success: bool) -> Result<(), ()> {
+    if success {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
 struct SplitLoader {
     state: Mutex<SplitLoaderState>,
 }
 
-enum SplitLoaderState {
-    Pending(Vec<Waker>),
-    Done(bool),
-}
-
 impl SplitLoader {
-    fn new() -> Self {
-        Self {
-            state: Mutex::new(SplitLoaderState::Pending(Vec::new())),
-        }
-    }
-
     fn complete(&self, value: bool) {
-        let wakers = {
+        let waker = {
             let mut state = self.state.lock().expect("lock poisoned");
             match std::mem::replace(&mut *state, SplitLoaderState::Done(value)) {
-                SplitLoaderState::Pending(wakers) => wakers,
-                // The load function's contract is one callback per invocation;
-                // tolerate a duplicate rather than corrupting state.
-                SplitLoaderState::Done(_) => Vec::new(),
+                SplitLoaderState::Pending(waker) => waker,
+                // Calling back twice for one invocation violates the documented
+                // load contract (and would already have been a double `from_raw`
+                // in `load_callback`); nothing useful to do here.
+                SplitLoaderState::Done(_) => None,
             }
         };
-        for waker in wakers {
+        if let Some(waker) = waker {
             waker.wake();
         }
     }
 }
 
-struct SplitLoaderFuture {
-    shared: Arc<SplitLoader>,
+enum SplitLoaderState {
+    Pending(Option<Waker>),
+    Done(bool),
 }
 
-impl Future for SplitLoaderFuture {
-    type Output = bool;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<bool> {
-        let mut state = self.shared.state.lock().expect("lock poisoned");
-        match &mut *state {
-            SplitLoaderState::Done(value) => Poll::Ready(*value),
-            SplitLoaderState::Pending(wakers) => {
-                if !wakers.iter().any(|w| w.will_wake(cx.waker())) {
-                    wakers.push(cx.waker().clone());
-                }
-                Poll::Pending
-            }
+impl SplitLoaderState {
+    fn done_value(&self) -> Option<bool> {
+        match self {
+            SplitLoaderState::Done(v) => Some(*v),
+            SplitLoaderState::Pending(_) => None,
         }
     }
 }
@@ -160,8 +171,6 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::task::{RawWaker, RawWakerVTable};
 
-    // Drive a future to completion with a no-op waker. The test load fns
-    // complete synchronously inside `load`, so polling in a loop suffices.
     fn block_on<F: Future>(fut: F) -> F::Output {
         fn noop_raw_waker() -> RawWaker {
             fn no_op(_: *const ()) {}
@@ -199,39 +208,34 @@ mod tests {
     }
 
     #[test]
-    fn retries_within_one_call_until_success() {
-        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        reset_script(3); // fail, fail, succeed
-        let loader = unsafe { LazySplitLoader::new(scripted_load) };
-        block_on(ensure_loaded(Pin::new(&loader)));
-        assert_eq!(CALLS.load(Ordering::SeqCst), 3);
-        // Once Ready, no further load invocations.
-        block_on(ensure_loaded(Pin::new(&loader)));
-        assert_eq!(CALLS.load(Ordering::SeqCst), 3);
-    }
-
-    #[test]
-    fn later_call_retries_after_exhausted_call() {
-        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        reset_script(MAX_ATTEMPTS_PER_CALL + 1); // first call exhausts its budget
-        let loader = unsafe { LazySplitLoader::new(scripted_load) };
-        let exhausted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            block_on(ensure_loaded(Pin::new(&loader)));
-        }));
-        assert!(exhausted.is_err(), "first call should give up");
-        assert_eq!(CALLS.load(Ordering::SeqCst), MAX_ATTEMPTS_PER_CALL);
-        // The failure must NOT be cached: a later call starts fresh and succeeds.
-        block_on(ensure_loaded(Pin::new(&loader)));
-        assert_eq!(CALLS.load(Ordering::SeqCst), MAX_ATTEMPTS_PER_CALL + 1);
-    }
-
-    #[test]
     fn immediate_success_loads_once() {
         let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_script(1);
         let loader = unsafe { LazySplitLoader::new(scripted_load) };
         block_on(ensure_loaded(Pin::new(&loader)));
         block_on(ensure_loaded(Pin::new(&loader)));
+        // Memoized: the second call does not re-invoke the load fn.
         assert_eq!(CALLS.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn failed_load_is_not_cached_and_a_later_call_retries() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_script(2); // first attempt fails, second succeeds
+        let loader = unsafe { LazySplitLoader::new(scripted_load) };
+
+        let first = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            block_on(ensure_loaded(Pin::new(&loader)));
+        }));
+        assert!(first.is_err(), "a failed load should panic the call");
+        assert_eq!(CALLS.load(Ordering::SeqCst), 1);
+
+        // The failure must NOT be cached: a later call starts fresh and succeeds.
+        block_on(ensure_loaded(Pin::new(&loader)));
+        assert_eq!(CALLS.load(Ordering::SeqCst), 2);
+
+        // And once loaded it stays memoized.
+        block_on(ensure_loaded(Pin::new(&loader)));
+        assert_eq!(CALLS.load(Ordering::SeqCst), 2);
     }
 }

--- a/crates/wasm_split/src/rt.rs
+++ b/crates/wasm_split/src/rt.rs
@@ -13,12 +13,10 @@ pub type LoadFn = unsafe extern "C" fn(LoadCallbackFn, *const c_void) -> ();
 
 /// A split-module load attempt failed.
 ///
-/// The failure is **not** cached: a later [`ensure_loaded`] call (or a later
-/// invocation of a `fallible` split function / its `preload`) starts a fresh
-/// attempt, so a transient network failure can be recovered from simply by
-/// retrying. See CHANGELOG / issue #35.
+/// Exact error information is currently not tracked but logged to the browser
+/// console. If you need access to the details, please open an issue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SplitLoaderError;
+pub struct SplitLoaderError(());
 
 impl std::fmt::Display for SplitLoaderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -28,15 +26,10 @@ impl std::fmt::Display for SplitLoaderError {
 
 impl std::error::Error for SplitLoaderError {}
 
-/// Loads a split module on demand.
+/// Loads a split module on demand, memoizing only successful loads.
 ///
-/// Backed by [`async_once_cell::OnceCell`]: a *successful* load is memoized so
-/// the module is only ever loaded once, but a *failed* load leaves the cell
-/// uninitialized, so a later `ensure_loaded` call retries from scratch. This is
-/// what prevents a single transient load failure (flaky network, aborted
-/// request) from bricking the split module for the lifetime of the session.
-/// The failure is surfaced as [`SplitLoaderError`] rather than cached, so the
-/// caller decides whether to retry. See CHANGELOG / issue #35.
+/// A failed load leaves the loader uninitialized, so a later `ensure_loaded`
+/// retries from scratch rather than caching the failure for the session.
 pub struct LazySplitLoader {
     load: LoadFn,
     cell: OnceCell<()>,
@@ -59,24 +52,21 @@ impl LazySplitLoader {
 /// Ensures the split module is loaded, returning [`SplitLoaderError`] if the
 /// load attempt failed.
 ///
-/// On failure the loader state is left uninitialized rather than caching the
-/// error, so simply calling `ensure_loaded` again starts a fresh attempt — this
-/// is how a transient network failure is recovered from. A `#[wasm_split(..)]`
-/// function opts into seeing this error by adding the `fallible` option;
-/// otherwise the generated wrapper `.expect()`s success.
+/// On failure the loader is left uninitialized rather than caching the error,
+/// so calling `ensure_loaded` again starts a fresh attempt. A `#[wasm_split(..)]`
+/// function opts into seeing this error via the `fallible` option; otherwise the
+/// generated wrapper expects a successful load.
 pub async fn ensure_loaded(loader: Pin<&LazySplitLoader>) -> Result<(), SplitLoaderError> {
     // SAFETY: pin projection; `LazySplitLoader` is never moved out of.
     let loader = loader.get_ref();
-    // `OnceCell` runs the init future once, serializing concurrent callers onto
-    // a single in-flight attempt and waking them all when it settles. On `Err`
-    // the cell stays empty, so a subsequent `ensure_loaded` starts a fresh
-    // attempt rather than caching the failure.
+    // `OnceCell` runs the init future once, serializing concurrent callers onto a
+    // single in-flight attempt. On `Err` the cell stays empty, so a later call
+    // starts a fresh attempt rather than caching the failure.
     loader
         .cell
         .get_or_try_init(SplitLoaderFuture::new(loader.load))
         .await
-        .map(|_: &()| ())
-        .map_err(|()| SplitLoaderError)
+        .map(|_| ())
 }
 
 unsafe extern "C" fn load_callback(loader: *const c_void, success: bool) {
@@ -84,67 +74,69 @@ unsafe extern "C" fn load_callback(loader: *const c_void, success: bool) {
     unsafe { Arc::<SplitLoader>::from_raw(loader.cast()) }.complete(success);
 }
 
-/// Bridges the FFI callback into a `Future`. One instance exists per load
-/// attempt and is polled by exactly one task (`OnceCell` serializes init), so a
-/// single optional waker suffices — there is no need to track multiple waiters
-/// here. Resolves `Ok(())` on success and `Err(())` on failure.
+enum SplitLoaderFutState {
+    Deferred(LoadFn),
+    Pending(Arc<SplitLoader>),
+}
+
 struct SplitLoaderFuture {
-    load: LoadFn,
-    shared: Option<Arc<SplitLoader>>,
+    state: SplitLoaderFutState,
 }
 
 impl SplitLoaderFuture {
-    fn new(load: LoadFn) -> Self {
-        Self { load, shared: None }
-    }
-}
-
-impl Future for SplitLoaderFuture {
-    type Output = Result<(), ()>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), ()>> {
-        match &self.shared {
-            // First poll: kick off the load. The callback (sync or async) drives
-            // `complete`. Not under any lock, so a synchronous callback is fine.
-            None => {
-                let shared = Arc::new(SplitLoader {
-                    state: Mutex::new(SplitLoaderState::Pending(Some(cx.waker().clone()))),
-                });
-                // SAFETY: contract upheld by the caller of `LazySplitLoader::new`;
-                // the matching `from_raw` happens in `load_callback`.
-                unsafe {
-                    (self.load)(
-                        load_callback,
-                        Arc::<SplitLoader>::into_raw(shared.clone()).cast(),
-                    )
-                };
-                // A synchronous callback may already have marked it Done.
-                let done = shared.state.lock().expect("lock poisoned").done_value();
-                self.shared = Some(shared);
-                match done {
-                    Some(success) => Poll::Ready(ok_or_err(success)),
-                    None => Poll::Pending,
-                }
-            }
-            Some(shared) => {
-                let mut state = shared.state.lock().expect("lock poisoned");
-                match &mut *state {
-                    SplitLoaderState::Done(success) => Poll::Ready(ok_or_err(*success)),
-                    SplitLoaderState::Pending(waker) => {
-                        *waker = Some(cx.waker().clone());
-                        Poll::Pending
-                    }
-                }
-            }
+    const fn new(load: LoadFn) -> Self {
+        SplitLoaderFuture {
+            state: SplitLoaderFutState::Deferred(load),
         }
     }
 }
 
-fn ok_or_err(success: bool) -> Result<(), ()> {
+impl Future for SplitLoaderFuture {
+    type Output = Result<(), SplitLoaderError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), SplitLoaderError>> {
+        match self.state {
+            SplitLoaderFutState::Deferred(load) => {
+                let shared_state = Arc::new(SplitLoader {
+                    state: Mutex::new(SplitLoaderState::Waiting(cx.waker().clone())),
+                });
+                // SAFETY: the contract is upheld by the caller of `LazySplitLoader::new`;
+                // the matching `from_raw` happens in `load_callback`. A synchronous
+                // callback completes `shared_state` and wakes this waker, so the future
+                // is re-polled and observes `Done` below.
+                unsafe {
+                    load(
+                        load_callback,
+                        Arc::<SplitLoader>::into_raw(shared_state.clone()).cast(),
+                    )
+                };
+                self.state = SplitLoaderFutState::Pending(shared_state);
+                Poll::Pending
+            }
+            SplitLoaderFutState::Pending(ref state) => state.update(|state| match state {
+                SplitLoaderState::Done(value) => Poll::Ready(load_result(*value)),
+                SplitLoaderState::Waiting(ref mut waker) => {
+                    *waker = cx.waker().clone();
+                    Poll::Pending
+                }
+            }),
+        }
+    }
+}
+
+// our future should never get canceled before completion. We could assert this?
+// impl Drop for SplitLoaderFuture { }
+
+/// Maps the success flag from the load callback into the public load result.
+/// This is the single place a [`SplitLoaderError`] is constructed, ready to
+/// carry richer detail in the future.
+fn load_result(success: bool) -> Result<(), SplitLoaderError> {
+    // Equivalent to `success.then_some(()).ok_or(SplitLoaderError(()))`, or
+    // `success.ok_or(SplitLoaderError(()))` should `bool::ok_or` ever stabilize.
     if success {
         Ok(())
     } else {
-        Err(())
+        Err(SplitLoaderError(()))
     }
 }
 
@@ -153,35 +145,27 @@ struct SplitLoader {
 }
 
 impl SplitLoader {
+    /// Runs `f` while holding the state lock. Keeping every caller's closure
+    /// panic-free is what guarantees the lock is never poisoned, so the
+    /// `expect("lock poisoned")` never fires.
+    fn update<R>(&self, f: impl FnOnce(&mut SplitLoaderState) -> R) -> R {
+        let mut state = self.state.lock().expect("lock poisoned");
+        f(&mut state)
+    }
     fn complete(&self, value: bool) {
-        let waker = {
-            let mut state = self.state.lock().expect("lock poisoned");
-            match std::mem::replace(&mut *state, SplitLoaderState::Done(value)) {
-                SplitLoaderState::Pending(waker) => waker,
-                // Calling back twice for one invocation violates the documented
-                // load contract (and would already have been a double `from_raw`
-                // in `load_callback`); nothing useful to do here.
-                SplitLoaderState::Done(_) => None,
+        self.update(|state| {
+            if let SplitLoaderState::Waiting(waker) =
+                std::mem::replace(state, SplitLoaderState::Done(value))
+            {
+                waker.wake();
             }
-        };
-        if let Some(waker) = waker {
-            waker.wake();
-        }
+        });
     }
 }
 
 enum SplitLoaderState {
-    Pending(Option<Waker>),
+    Waiting(Waker),
     Done(bool),
-}
-
-impl SplitLoaderState {
-    fn done_value(&self) -> Option<bool> {
-        match self {
-            SplitLoaderState::Done(v) => Some(*v),
-            SplitLoaderState::Pending(_) => None,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -246,7 +230,7 @@ mod tests {
         // A failed load surfaces as `Err` rather than panicking.
         assert_eq!(
             block_on(ensure_loaded(Pin::new(&loader))),
-            Err(SplitLoaderError)
+            Err(SplitLoaderError(()))
         );
         assert_eq!(CALLS.load(Ordering::SeqCst), 1);
 
@@ -286,7 +270,7 @@ mod tests {
             body_runs.fetch_add(1, Ordering::SeqCst);
             42
         }));
-        assert_eq!(first, Err(SplitLoaderError));
+        assert_eq!(first, Err(SplitLoaderError(())));
         assert_eq!(
             body_runs.load(Ordering::SeqCst),
             0,

--- a/crates/wasm_split/src/rt.rs
+++ b/crates/wasm_split/src/rt.rs
@@ -11,15 +11,32 @@ use async_once_cell::OnceCell;
 pub type LoadCallbackFn = unsafe extern "C" fn(*const c_void, bool) -> ();
 pub type LoadFn = unsafe extern "C" fn(LoadCallbackFn, *const c_void) -> ();
 
+/// A split-module load attempt failed.
+///
+/// The failure is **not** cached: a later [`ensure_loaded`] call (or a later
+/// invocation of a `fallible` split function / its `preload`) starts a fresh
+/// attempt, so a transient network failure can be recovered from simply by
+/// retrying. See CHANGELOG / issue #35.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SplitLoaderError;
+
+impl std::fmt::Display for SplitLoaderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("failed to load split module")
+    }
+}
+
+impl std::error::Error for SplitLoaderError {}
+
 /// Loads a split module on demand.
 ///
 /// Backed by [`async_once_cell::OnceCell`]: a *successful* load is memoized so
 /// the module is only ever loaded once, but a *failed* load leaves the cell
 /// uninitialized, so a later `ensure_loaded` call retries from scratch. This is
 /// what prevents a single transient load failure (flaky network, aborted
-/// request) from bricking the split module for the lifetime of the session —
-/// the generated JS loader additionally retries the fetch itself with backoff,
-/// so reaching a hard failure here is rare. See CHANGELOG / issue #35.
+/// request) from bricking the split module for the lifetime of the session.
+/// The failure is surfaced as [`SplitLoaderError`] rather than cached, so the
+/// caller decides whether to retry. See CHANGELOG / issue #35.
 pub struct LazySplitLoader {
     load: LoadFn,
     cell: OnceCell<()>,
@@ -39,25 +56,27 @@ impl LazySplitLoader {
     }
 }
 
-pub async fn ensure_loaded(loader: Pin<&LazySplitLoader>) {
+/// Ensures the split module is loaded, returning [`SplitLoaderError`] if the
+/// load attempt failed.
+///
+/// On failure the loader state is left uninitialized rather than caching the
+/// error, so simply calling `ensure_loaded` again starts a fresh attempt — this
+/// is how a transient network failure is recovered from. A `#[wasm_split(..)]`
+/// function opts into seeing this error by adding the `fallible` option;
+/// otherwise the generated wrapper `.expect()`s success.
+pub async fn ensure_loaded(loader: Pin<&LazySplitLoader>) -> Result<(), SplitLoaderError> {
     // SAFETY: pin projection; `LazySplitLoader` is never moved out of.
     let loader = loader.get_ref();
     // `OnceCell` runs the init future once, serializing concurrent callers onto
     // a single in-flight attempt and waking them all when it settles. On `Err`
     // the cell stays empty, so a subsequent `ensure_loaded` starts a fresh
     // attempt rather than caching the failure.
-    let result = loader
+    loader
         .cell
         .get_or_try_init(SplitLoaderFuture::new(loader.load))
-        .await;
-    if result.is_err() {
-        // The load contract is infallible from the caller's side (the generated
-        // code treats split modules as must-load), so a hard failure that even
-        // the JS-side fetch retries couldn't recover panics — but unlike the
-        // previous implementation it is NOT cached, so reloading / a later
-        // navigation can succeed.
-        panic!("load callback should succeed");
-    }
+        .await
+        .map(|_: &()| ())
+        .map_err(|()| SplitLoaderError)
 }
 
 unsafe extern "C" fn load_callback(loader: *const c_void, success: bool) {
@@ -212,8 +231,8 @@ mod tests {
         let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_script(1);
         let loader = unsafe { LazySplitLoader::new(scripted_load) };
-        block_on(ensure_loaded(Pin::new(&loader)));
-        block_on(ensure_loaded(Pin::new(&loader)));
+        assert!(block_on(ensure_loaded(Pin::new(&loader))).is_ok());
+        assert!(block_on(ensure_loaded(Pin::new(&loader))).is_ok());
         // Memoized: the second call does not re-invoke the load fn.
         assert_eq!(CALLS.load(Ordering::SeqCst), 1);
     }
@@ -224,18 +243,63 @@ mod tests {
         reset_script(2); // first attempt fails, second succeeds
         let loader = unsafe { LazySplitLoader::new(scripted_load) };
 
-        let first = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            block_on(ensure_loaded(Pin::new(&loader)));
-        }));
-        assert!(first.is_err(), "a failed load should panic the call");
+        // A failed load surfaces as `Err` rather than panicking.
+        assert_eq!(
+            block_on(ensure_loaded(Pin::new(&loader))),
+            Err(SplitLoaderError)
+        );
         assert_eq!(CALLS.load(Ordering::SeqCst), 1);
 
         // The failure must NOT be cached: a later call starts fresh and succeeds.
-        block_on(ensure_loaded(Pin::new(&loader)));
+        assert!(block_on(ensure_loaded(Pin::new(&loader))).is_ok());
         assert_eq!(CALLS.load(Ordering::SeqCst), 2);
 
         // And once loaded it stays memoized.
-        block_on(ensure_loaded(Pin::new(&loader)));
+        assert!(block_on(ensure_loaded(Pin::new(&loader))).is_ok());
         assert_eq!(CALLS.load(Ordering::SeqCst), 2);
+    }
+
+    // Mirrors the glue that `#[wasm_split(.., fallible)]` generates for a
+    // wrapper: `preload().await?; Ok({ <body> })` (where `preload` is a thin
+    // wrapper over `ensure_loaded`). The browser test harness can't inject a
+    // real load failure, so this asserts the macro-emitted shape directly: a
+    // failed load short-circuits to `Err` *without* running the body, and a
+    // later call recovers because the failure was not cached.
+    #[test]
+    fn fallible_wrapper_shape_short_circuits_then_recovers() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_script(2); // first attempt fails, second succeeds
+        let loader = unsafe { LazySplitLoader::new(scripted_load) };
+
+        async fn fallible_wrapper(
+            loader: Pin<&LazySplitLoader>,
+            body: impl FnOnce() -> u32,
+        ) -> Result<u32, SplitLoaderError> {
+            ensure_loaded(loader).await?;
+            Ok(body())
+        }
+
+        let body_runs = AtomicUsize::new(0);
+
+        // Load fails -> `Err`, and the wrapped body never runs.
+        let first = block_on(fallible_wrapper(Pin::new(&loader), || {
+            body_runs.fetch_add(1, Ordering::SeqCst);
+            42
+        }));
+        assert_eq!(first, Err(SplitLoaderError));
+        assert_eq!(
+            body_runs.load(Ordering::SeqCst),
+            0,
+            "the function body must not run when the load fails"
+        );
+
+        // Caller retries: the failure was not cached, so the load now succeeds,
+        // the body runs, and the wrapper yields `Ok`.
+        let second = block_on(fallible_wrapper(Pin::new(&loader), || {
+            body_runs.fetch_add(1, Ordering::SeqCst);
+            42
+        }));
+        assert_eq!(second, Ok(42));
+        assert_eq!(body_runs.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/wasm_split_cli/src/snippets/makeFetch.web.js
+++ b/crates/wasm_split_cli/src/snippets/makeFetch.web.js
@@ -3,25 +3,9 @@ function makeFetch(srcUrl) {
         return () => { return async (_imports) => { return {} } };
     }
     return () => {
-        // Start the first fetch eagerly so the download overlaps with loading
-        // this module's dependencies.
-        let src = fetch(srcUrl);
+        const src = fetch(srcUrl);
         return async (imports) => {
-            // A transient network failure (flaky connection, aborted request,
-            // momentary 5xx) shouldn't fail the whole load: retry a couple of
-            // times with a short backoff before reporting failure.
-            const RETRIES = 2;
-            const BASE_DELAY_MS = 250;
-            for (let attempt = 0; ; attempt++) {
-                try {
-                    return await WebAssembly.instantiateStreaming(src, imports);
-                } catch (e) {
-                    if (attempt >= RETRIES) throw e;
-                    await new Promise(resolve => setTimeout(resolve, BASE_DELAY_MS * 2 ** attempt));
-                    // A Response body is single-use; retries need a new fetch.
-                    src = fetch(srcUrl);
-                }
-            }
+            return await WebAssembly.instantiateStreaming(src, imports);
         }
     }
 }

--- a/crates/wasm_split_cli/src/snippets/makeFetch.web.js
+++ b/crates/wasm_split_cli/src/snippets/makeFetch.web.js
@@ -3,9 +3,25 @@ function makeFetch(srcUrl) {
         return () => { return async (_imports) => { return {} } };
     }
     return () => {
-        const src = fetch(srcUrl);
+        // Start the first fetch eagerly so the download overlaps with loading
+        // this module's dependencies.
+        let src = fetch(srcUrl);
         return async (imports) => {
-            return await WebAssembly.instantiateStreaming(src, imports);
+            // A transient network failure (flaky connection, aborted request,
+            // momentary 5xx) shouldn't fail the whole load: retry a couple of
+            // times with a short backoff before reporting failure.
+            const RETRIES = 2;
+            const BASE_DELAY_MS = 250;
+            for (let attempt = 0; ; attempt++) {
+                try {
+                    return await WebAssembly.instantiateStreaming(src, imports);
+                } catch (e) {
+                    if (attempt >= RETRIES) throw e;
+                    await new Promise(resolve => setTimeout(resolve, BASE_DELAY_MS * 2 ** attempt));
+                    // A Response body is single-use; retries need a new fetch.
+                    src = fetch(srcUrl);
+                }
+            }
         }
     }
 }

--- a/crates/wasm_split_cli/src/snippets/split_wasm.js
+++ b/crates/wasm_split_cli/src/snippets/split_wasm.js
@@ -24,7 +24,18 @@ function makeLoad(fetchOpts, deps) {
     };
     let loadingModule = undefined;
     return () => {
-        if (loadingModule === undefined) loadingModule = loader();
+        if (loadingModule === undefined) {
+            const thisLoad = loader();
+            // Memoize successes only: a rejected load must not be cached for
+            // the lifetime of the session, or one transient network failure
+            // permanently breaks the module. Clearing on rejection lets the
+            // next call (e.g. the Rust side re-invoking load after a failed
+            // callback) start a fresh attempt.
+            thisLoad.catch(() => {
+                if (loadingModule === thisLoad) loadingModule = undefined;
+            });
+            loadingModule = thisLoad;
+        }
         return loadingModule;
     }
 }

--- a/crates/wasm_split_macros/src/lib.rs
+++ b/crates/wasm_split_macros/src/lib.rs
@@ -136,10 +136,12 @@ impl Parse for Args {
 ///   fetches the module in which the wrapped function is contained without calling it. Its signature is `async fn()`
 ///   and a hard load failure panics, matching the wrapper; with the `fallible` option it instead returns
 ///   `Result<(), wasm_split_helpers::SplitLoaderError>`.
-/// - `fallible` makes the generated wrapper (and the `preload` function, if any) return
-///   `Result<_, wasm_split_helpers::SplitLoaderError>`, surfacing a load failure as `Err` instead of panicking (a panic
-///   aborts the whole wasm module). Without this option both keep their infallible signatures and a hard load failure
-///   panics, as before. The failure is never cached, so a later call retries from scratch.
+/// - `fallible` surfaces a load failure as `Err` instead of panicking (a panic aborts the whole wasm module). The
+///   annotated function must return `Result<_, E>` where `E: From<wasm_split_helpers::SplitLoaderError>`; the macro
+///   leaves that signature untouched and converts a load failure into your `E` via `?`, so a use-site can fold it
+///   straight into a framework-specific error. The generated `preload` function (if any) returns
+///   `Result<(), wasm_split_helpers::SplitLoaderError>`. Without this option both keep their infallible signatures and
+///   a hard load failure panics, as before. The failure is never cached, so a later call retries from scratch.
 ///
 /// [this blog post]: https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/#what-is-going-to-break-and-how-to-fix
 #[proc_macro_attribute]
@@ -299,12 +301,11 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
         })).await
     };
     let (preload_output, preload_load, preload_tail, load_and_compute) = if fallible {
-        let inner_output: syn::Type = match &wrapper_sig.output {
-            ReturnType::Default => parse_quote!(()),
-            ReturnType::Type(_, ty) => (**ty).clone(),
-        };
-        wrapper_sig.output =
-            parse_quote!(-> ::core::result::Result<#inner_output, #split_loader_error>);
+        // `fallible` keeps the user's own signature: they must return
+        // `Result<_, E>` where `E: From<SplitLoaderError>`. We do NOT synthesize
+        // the return type. `#preload_name().await?` converts a load failure into
+        // the user's `E` via `?`/`From`, so a use-site can fold it straight into
+        // a framework error (e.g. leptos surfacing it to `<ErrorBoundary>`).
         (
             quote!(-> ::core::result::Result<(), #split_loader_error>),
             quote! { return #ensure_loaded; },
@@ -312,7 +313,7 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! { #[allow(unreachable_code)] ::core::result::Result::Ok(()) },
             quote! {
                 #preload_name().await?;
-                ::core::result::Result::Ok({ #compute_result })
+                #compute_result
             },
         )
     } else {

--- a/crates/wasm_split_macros/src/lib.rs
+++ b/crates/wasm_split_macros/src/lib.rs
@@ -27,6 +27,7 @@ struct Args {
     wasm_split_path: Option<Path>,
     return_wrapper: Option<ReturnWrapper>,
     preload_def: Option<PreloadDefinition>,
+    fallible: bool,
 }
 
 impl Parse for Args {
@@ -36,6 +37,7 @@ impl Parse for Args {
         let mut wasm_split_path = None;
         let mut return_wrapper = None;
         let mut preload_def = None;
+        let mut fallible = false;
         while !input.is_empty() {
             let _: Token![,] = input.parse()?;
             if input.is_empty() {
@@ -72,6 +74,9 @@ impl Parse for Args {
                     let name = wrap_spec.parse()?;
                     preload_def = Some(PreloadDefinition { attrs, name });
                 }
+                _ if option == "fallible" => {
+                    fallible = true;
+                }
                 _ => {
                     return Err(syn::Error::new(
                         option.span(),
@@ -86,6 +91,7 @@ impl Parse for Args {
             wasm_split_path,
             return_wrapper,
             preload_def,
+            fallible,
         })
     }
 }
@@ -127,8 +133,13 @@ impl Parse for Args {
 ///   Example use case: `return_wrapper( let future = _ ; { future.await } -> Output)` to `await` a future directly in
 ///   the wrapper.
 /// - `preload( $( #[$attr] )* $preload_name:ident )` generates an additional preload function `$preload_name` with the
-///   signature `async fn()` which can be used to fetch the module in which the wrapped function is contained without
-///   calling it.
+///   signature `async fn() -> Result<(), wasm_split_helpers::rt::SplitLoaderError>` which can be used to fetch the
+///   module in which the wrapped function is contained without calling it. A failed load is reported as `Err` and is
+///   not cached, so calling the preload again retries.
+/// - `fallible` wraps the generated wrapper's return type in
+///   `Result<_, wasm_split_helpers::rt::SplitLoaderError>` and returns `Err` when the module fails to load, instead of
+///   panicking (a panic aborts the whole wasm module). Without this option the wrapper `.expect()`s a successful load.
+///   The failure is never cached, so a later call retries from scratch.
 ///
 /// [this blog post]: https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/#what-is-going-to-break-and-how-to-fix
 #[proc_macro_attribute]
@@ -139,6 +150,7 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
         wasm_split_path,
         return_wrapper,
         preload_def,
+        fallible,
     } = parse_macro_input!(args as Args);
     let (deprecated_link_opt, link_name) = if let Some((option, link_name)) = link_name {
         (Some(option), link_name)
@@ -271,6 +283,31 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
         }};
     }
 
+    // The generated `preload` function surfaces a load failure as
+    // `Result<(), SplitLoaderError>`. With the `fallible` option, the wrapper
+    // propagates that error: its return type is wrapped in `Result<_, _>` and a
+    // failed load returns `Err` instead of panicking (a panic aborts the whole
+    // wasm module). Without it, the wrapper `.expect()`s success, preserving the
+    // historical behavior.
+    let split_loader_error = quote!(#wasm_split_path::rt::SplitLoaderError);
+    let load_and_compute = if fallible {
+        let inner_output: syn::Type = match &wrapper_sig.output {
+            ReturnType::Default => parse_quote!(()),
+            ReturnType::Type(_, ty) => (**ty).clone(),
+        };
+        wrapper_sig.output =
+            parse_quote!(-> ::core::result::Result<#inner_output, #split_loader_error>);
+        quote! {
+            #preload_name().await?;
+            ::core::result::Result::Ok({ #compute_result })
+        }
+    } else {
+        quote! {
+            #preload_name().await.expect("failed to load split module");
+            #compute_result
+        }
+    };
+
     let mut extra_code = quote! {};
     if let Some(deprecated_opt) = deprecated_link_opt {
         let deprecation_note = format!("The `{deprecated_opt}` option should not be used, since the wasm_split_cli fixes the import path with improved target knowledge.");
@@ -287,7 +324,7 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
     quote! {
         // This could have weak linkage to unify all mentions of the same module
         #( #preload_attrs )*
-        #vis async fn #preload_name () {
+        #vis async fn #preload_name () -> ::core::result::Result<(), #split_loader_error> {
             #[cfg(target_family = "wasm")]
             #[link(wasm_import_module = #link_name)]
             unsafe extern "C" {
@@ -296,12 +333,15 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
             }
             #[cfg(target_family = "wasm")]
             {
-                #wasm_split_path::rt::ensure_loaded(::core::pin::Pin::static_ref({
+                return #wasm_split_path::rt::ensure_loaded(::core::pin::Pin::static_ref({
                     // SAFETY: the imported c function correctly implements the callback
                     static LOADER: #wasm_split_path::rt::LazySplitLoader = unsafe { #wasm_split_path::rt::LazySplitLoader::new(#load_module_ident) };
                     &LOADER
                 })).await;
             }
+            // On non-wasm targets the function is called directly; nothing to load.
+            #[allow(unreachable_code)]
+            ::core::result::Result::Ok(())
         }
         #(#attrs)*
         #vis #wrapper_sig {
@@ -332,8 +372,7 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
                 #(#stmts)*
             }
 
-            #preload_name ().await;
-            #compute_result
+            #load_and_compute
         }
         #extra_code
     }

--- a/crates/wasm_split_macros/src/lib.rs
+++ b/crates/wasm_split_macros/src/lib.rs
@@ -132,14 +132,14 @@ impl Parse for Args {
 ///
 ///   Example use case: `return_wrapper( let future = _ ; { future.await } -> Output)` to `await` a future directly in
 ///   the wrapper.
-/// - `preload( $( #[$attr] )* $preload_name:ident )` generates an additional preload function `$preload_name` with the
-///   signature `async fn() -> Result<(), wasm_split_helpers::SplitLoaderError>` which can be used to fetch the
-///   module in which the wrapped function is contained without calling it. A failed load is reported as `Err` and is
-///   not cached, so calling the preload again retries.
-/// - `fallible` wraps the generated wrapper's return type in
-///   `Result<_, wasm_split_helpers::SplitLoaderError>` and returns `Err` when the module fails to load, instead of
-///   panicking (a panic aborts the whole wasm module). Without this option the wrapper `.expect()`s a successful load.
-///   The failure is never cached, so a later call retries from scratch.
+/// - `preload( $( #[$attr] )* $preload_name:ident )` generates an additional preload function `$preload_name` that
+///   fetches the module in which the wrapped function is contained without calling it. Its signature is `async fn()`
+///   and a hard load failure panics, matching the wrapper; with the `fallible` option it instead returns
+///   `Result<(), wasm_split_helpers::SplitLoaderError>`.
+/// - `fallible` makes the generated wrapper (and the `preload` function, if any) return
+///   `Result<_, wasm_split_helpers::SplitLoaderError>`, surfacing a load failure as `Err` instead of panicking (a panic
+///   aborts the whole wasm module). Without this option both keep their infallible signatures and a hard load failure
+///   panics, as before. The failure is never cached, so a later call retries from scratch.
 ///
 /// [this blog post]: https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/#what-is-going-to-break-and-how-to-fix
 #[proc_macro_attribute]
@@ -284,22 +284,47 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
     }
 
     let split_loader_error = quote!(#wasm_split_path::SplitLoaderError);
-    let load_and_compute = if fallible {
+    // The load is awaited inside `preload`. With `fallible`, both the wrapper
+    // and `preload` surface a load failure as `Result<_, SplitLoaderError>`;
+    // without it they keep their infallible signatures and a hard failure
+    // panics, exactly as before. Keeping `preload` infallible by default is
+    // load-bearing: existing callers expect `async fn() -> ()` — e.g. leptos's
+    // `LazyRoute::preload` is typed `Output = ()` — and changing that
+    // unconditionally would break them.
+    let ensure_loaded = quote! {
+        #wasm_split_path::rt::ensure_loaded(::core::pin::Pin::static_ref({
+            // SAFETY: the imported c function correctly implements the callback
+            static LOADER: #wasm_split_path::rt::LazySplitLoader = unsafe { #wasm_split_path::rt::LazySplitLoader::new(#load_module_ident) };
+            &LOADER
+        })).await
+    };
+    let (preload_output, preload_load, preload_tail, load_and_compute) = if fallible {
         let inner_output: syn::Type = match &wrapper_sig.output {
             ReturnType::Default => parse_quote!(()),
             ReturnType::Type(_, ty) => (**ty).clone(),
         };
         wrapper_sig.output =
             parse_quote!(-> ::core::result::Result<#inner_output, #split_loader_error>);
-        quote! {
-            #preload_name().await?;
-            ::core::result::Result::Ok({ #compute_result })
-        }
+        (
+            quote!(-> ::core::result::Result<(), #split_loader_error>),
+            quote! { return #ensure_loaded; },
+            // On non-wasm targets the function is called directly; nothing to load.
+            quote! { #[allow(unreachable_code)] ::core::result::Result::Ok(()) },
+            quote! {
+                #preload_name().await?;
+                ::core::result::Result::Ok({ #compute_result })
+            },
+        )
     } else {
-        quote! {
-            #preload_name().await.expect("failed to load split module");
-            #compute_result
-        }
+        (
+            quote!(),
+            quote! { #ensure_loaded.expect("load callback should succeed"); },
+            quote!(),
+            quote! {
+                #preload_name().await;
+                #compute_result
+            },
+        )
     };
 
     let mut extra_code = quote! {};
@@ -318,7 +343,7 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
     quote! {
         // This could have weak linkage to unify all mentions of the same module
         #( #preload_attrs )*
-        #vis async fn #preload_name () -> ::core::result::Result<(), #split_loader_error> {
+        #vis async fn #preload_name () #preload_output {
             #[cfg(target_family = "wasm")]
             #[link(wasm_import_module = #link_name)]
             unsafe extern "C" {
@@ -327,15 +352,9 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
             }
             #[cfg(target_family = "wasm")]
             {
-                return #wasm_split_path::rt::ensure_loaded(::core::pin::Pin::static_ref({
-                    // SAFETY: the imported c function correctly implements the callback
-                    static LOADER: #wasm_split_path::rt::LazySplitLoader = unsafe { #wasm_split_path::rt::LazySplitLoader::new(#load_module_ident) };
-                    &LOADER
-                })).await;
+                #preload_load
             }
-            // On non-wasm targets the function is called directly; nothing to load.
-            #[allow(unreachable_code)]
-            ::core::result::Result::Ok(())
+            #preload_tail
         }
         #(#attrs)*
         #vis #wrapper_sig {

--- a/crates/wasm_split_macros/src/lib.rs
+++ b/crates/wasm_split_macros/src/lib.rs
@@ -133,11 +133,11 @@ impl Parse for Args {
 ///   Example use case: `return_wrapper( let future = _ ; { future.await } -> Output)` to `await` a future directly in
 ///   the wrapper.
 /// - `preload( $( #[$attr] )* $preload_name:ident )` generates an additional preload function `$preload_name` with the
-///   signature `async fn() -> Result<(), wasm_split_helpers::rt::SplitLoaderError>` which can be used to fetch the
+///   signature `async fn() -> Result<(), wasm_split_helpers::SplitLoaderError>` which can be used to fetch the
 ///   module in which the wrapped function is contained without calling it. A failed load is reported as `Err` and is
 ///   not cached, so calling the preload again retries.
 /// - `fallible` wraps the generated wrapper's return type in
-///   `Result<_, wasm_split_helpers::rt::SplitLoaderError>` and returns `Err` when the module fails to load, instead of
+///   `Result<_, wasm_split_helpers::SplitLoaderError>` and returns `Err` when the module fails to load, instead of
 ///   panicking (a panic aborts the whole wasm module). Without this option the wrapper `.expect()`s a successful load.
 ///   The failure is never cached, so a later call retries from scratch.
 ///
@@ -283,13 +283,7 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
         }};
     }
 
-    // The generated `preload` function surfaces a load failure as
-    // `Result<(), SplitLoaderError>`. With the `fallible` option, the wrapper
-    // propagates that error: its return type is wrapped in `Result<_, _>` and a
-    // failed load returns `Err` instead of panicking (a panic aborts the whole
-    // wasm module). Without it, the wrapper `.expect()`s success, preserving the
-    // historical behavior.
-    let split_loader_error = quote!(#wasm_split_path::rt::SplitLoaderError);
+    let split_loader_error = quote!(#wasm_split_path::SplitLoaderError);
     let load_and_compute = if fallible {
         let inner_output: syn::Type = match &wrapper_sig.output {
             ReturnType::Default => parse_quote!(()),

--- a/integration/simple/src/lib.rs
+++ b/integration/simple/src/lib.rs
@@ -41,6 +41,11 @@ fn preloadable() -> u32 {
     42
 }
 
+#[wasm_split(fallible_split, fallible)]
+fn fallible_lazy() -> u32 {
+    42
+}
+
 pub static SHARED_MUT: AtomicU32 = AtomicU32::new(0xdead);
 
 #[wasm_split(shared_mut)]
@@ -96,11 +101,20 @@ mod tests {
 
     #[test]
     pub async fn it_can_preload_a_split() {
-        crate::preload_it().await;
+        crate::preload_it().await.expect("preload should succeed");
         assert_eq!(
             crate::preloadable().await,
             42,
             "should execute the preloadable function correctly"
+        );
+    }
+
+    #[test]
+    pub async fn it_supports_fallible_wrappers() {
+        assert_eq!(
+            crate::fallible_lazy().await,
+            Ok(42),
+            "a fallible wrapper returns Ok(_) on a successful load"
         );
     }
 

--- a/integration/simple/src/lib.rs
+++ b/integration/simple/src/lib.rs
@@ -55,7 +55,10 @@ fn fallible_preloadable() -> Result<u32, SplitLoaderError> {
 
 // A use-site can declare its own error type as long as it is
 // `From<SplitLoaderError>`; the load failure folds straight into it.
+// On non-wasm the load can't fail, so `From::from` (and thus the only
+// construction site) is unreachable there -- allow the host-only dead code.
 #[derive(Debug, PartialEq)]
+#[allow(dead_code)]
 struct DemoError;
 
 impl From<SplitLoaderError> for DemoError {

--- a/integration/simple/src/lib.rs
+++ b/integration/simple/src/lib.rs
@@ -46,6 +46,11 @@ fn fallible_lazy() -> u32 {
     42
 }
 
+#[wasm_split(fallible_preload_split, preload(preload_fallible), fallible)]
+fn fallible_preloadable() -> u32 {
+    42
+}
+
 pub static SHARED_MUT: AtomicU32 = AtomicU32::new(0xdead);
 
 #[wasm_split(shared_mut)]
@@ -101,7 +106,9 @@ mod tests {
 
     #[test]
     pub async fn it_can_preload_a_split() {
-        crate::preload_it().await.expect("preload should succeed");
+        // A non-`fallible` preload keeps its `async fn() -> ()` signature, so
+        // this awaits a `()` (no `Result` to handle) exactly as before.
+        crate::preload_it().await;
         assert_eq!(
             crate::preloadable().await,
             42,
@@ -116,6 +123,15 @@ mod tests {
             Ok(42),
             "a fallible wrapper returns Ok(_) on a successful load"
         );
+    }
+
+    #[test]
+    pub async fn it_supports_fallible_preload() {
+        // With `fallible`, the preload returns `Result<(), SplitLoaderError>`.
+        crate::preload_fallible()
+            .await
+            .expect("preload should succeed");
+        assert_eq!(crate::fallible_preloadable().await, Ok(42));
     }
 
     #[test]

--- a/integration/simple/src/lib.rs
+++ b/integration/simple/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     pin::Pin,
     sync::atomic::{AtomicU32, Ordering},
 };
-use wasm_split_helpers::wasm_split;
+use wasm_split_helpers::{wasm_split, SplitLoaderError};
 
 #[wasm_split(split)]
 fn lazy() -> u32 {
@@ -41,14 +41,44 @@ fn preloadable() -> u32 {
     42
 }
 
+// `fallible` keeps the user's signature: the function returns its own
+// `Result<_, E>` and the macro converts a load failure into `E` via `?`/`From`.
 #[wasm_split(fallible_split, fallible)]
-fn fallible_lazy() -> u32 {
-    42
+fn fallible_lazy() -> Result<u32, SplitLoaderError> {
+    Ok(42)
 }
 
 #[wasm_split(fallible_preload_split, preload(preload_fallible), fallible)]
-fn fallible_preloadable() -> u32 {
-    42
+fn fallible_preloadable() -> Result<u32, SplitLoaderError> {
+    Ok(42)
+}
+
+// A use-site can declare its own error type as long as it is
+// `From<SplitLoaderError>`; the load failure folds straight into it.
+#[derive(Debug, PartialEq)]
+struct DemoError;
+
+impl From<SplitLoaderError> for DemoError {
+    fn from(_: SplitLoaderError) -> Self {
+        DemoError
+    }
+}
+
+#[wasm_split(custom_err_split, fallible)]
+fn custom_err_lazy() -> Result<u32, DemoError> {
+    Ok(42)
+}
+
+// `fallible` composed with `return_wrapper` (an async wrapper) -- the exact shape
+// leptos generates for an async lazy-route view. The awaited output must itself
+// be the `Result`, and `?` folds the load failure into it.
+#[wasm_split(
+    fallible_async_split,
+    fallible,
+    return_wrapper(let future = _ ; { future.await } -> Result<u32, SplitLoaderError>)
+)]
+fn fallible_async() -> Pin<Box<dyn Future<Output = Result<u32, SplitLoaderError>>>> {
+    Box::pin(async move { Ok(42) })
 }
 
 pub static SHARED_MUT: AtomicU32 = AtomicU32::new(0xdead);
@@ -132,6 +162,19 @@ mod tests {
             .await
             .expect("preload should succeed");
         assert_eq!(crate::fallible_preloadable().await, Ok(42));
+    }
+
+    #[test]
+    pub async fn it_supports_fallible_custom_error() {
+        // The wrapper keeps the user's signature; a load failure would convert
+        // into `DemoError` via `From<SplitLoaderError>`. On success it is `Ok`.
+        assert_eq!(crate::custom_err_lazy().await, Ok(42));
+    }
+
+    #[test]
+    pub async fn it_supports_fallible_with_return_wrapper() {
+        // `fallible` + `return_wrapper` (the leptos async-view shape).
+        assert_eq!(crate::fallible_async().await, Ok(42));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #35.

## Problem

A single transient chunk-fetch failure (flaky network, aborted request, momentary 5xx) currently has permanent consequences:

1. `makeFetch` makes exactly one fetch attempt;
2. `makeLoad` memoizes the **rejected** promise, so every later call gets the same failure;
3. on the Rust side, `async_once_cell::Lazy` caches the failed init, and `ensure_loaded` panics (`load callback should succeed`) — every subsequent `ensure_loaded` for that module re-polls the cached failure.

Net effect: the split module is dead for the rest of the session; a full page reload is the user's only remedy.

## Changes

**`makeFetch.web.js`** — retry transient failures (2 retries, 250 ms exponential backoff). The first fetch still starts eagerly so the download overlaps dependency loading; retries issue a fresh `fetch` since a `Response` body is single-use.

**`split_wasm.js` (`makeLoad`)** — memoize successful loads only: a rejection clears the memo (guarded against races with a newer load), so the next call starts a fresh attempt.

**`rt.rs`** — replace the `async_once_cell::Lazy` with a small retryable state machine:
- concurrent `ensure_loaded` callers share one in-flight attempt (multi-waker);
- a failed attempt resets the loader to `NotStarted`;
- `ensure_loaded` re-invokes the load function up to 3 times per call before giving up with the existing panic — and because the state was already reset, **later calls still start fresh** even after one call exhausted its budget.

Public API is unchanged: `LazySplitLoader::new` stays `const unsafe fn` (used in statics by the macro), `ensure_loaded(Pin<&LazySplitLoader>)` keeps its infallible signature. The `async_once_cell` dependency is dropped. One safety-contract doc change: the load function must call the callback exactly once **per invocation** (it can now be invoked more than once); the generated JS satisfies this.

## Testing

- New unit tests in `rt.rs`: retry-until-success within one call; budget exhaustion followed by a successful later call (the cached-failure regression); load-once on immediate success.
- `integration/`: full workspace passes natively and on `wasm32-unknown-unknown` in Chromium via chromedriver (8 browser tests through the modified loader path).
- `cargo test -p wasm_split_cli_support --all-features`, `cargo fmt --check`: clean.
- Real-world validation: the deterministic repro from #35 (Playwright aborts one `chunk_*.wasm` request mid-navigation) is what motivated the shape of the fix; we have an e2e regression test in our leptos app waiting on this change and are happy to validate a release or git ref against it.

Notes for review: the panic in `ensure_loaded` is retained as the final fallback because the generated callers treat loading as infallible — changing that signature ripples into the macro/codegen and felt out of scope here, but the panic now only fires after the per-call retry budget AND no longer poisons subsequent navigations. Happy to adjust retry counts/backoff or move them into the loader's configuration if you'd prefer.