### PR TITLE
Add a canary to imported symbols

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           toolchain: nightly
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
       - uses: cargo-bins/cargo-binstall@v1.15.9
       - run: cargo binstall just
+      - uses: Swatinem/rust-cache@v2
 
       - run: just fmt-check
 
@@ -35,9 +35,9 @@ jobs:
         with:
           toolchain: nightly
           components: clippy
-      - uses: Swatinem/rust-cache@v2
       - uses: cargo-bins/cargo-binstall@v1.15.9
       - run: cargo binstall just
+      - uses: Swatinem/rust-cache@v2
 
       - run: just clippy
 
@@ -52,9 +52,9 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
       - uses: cargo-bins/cargo-binstall@v1.15.9
       - run: cargo binstall just
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run integration tests
         run: xvfb-run just test-integrations

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - run: cargo binstall just
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces:
+          workspaces: |
             .
             integration
             test-runner
@@ -44,7 +44,7 @@ jobs:
       - run: cargo binstall just
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces:
+          workspaces: |
             .
             integration
             test-runner
@@ -66,7 +66,7 @@ jobs:
       - run: cargo binstall just
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces:
+          workspaces: |
             .
             integration
             test-runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,11 @@ jobs:
       - uses: cargo-bins/cargo-binstall@v1.15.9
       - run: cargo binstall just
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces:
+            .
+            integration
+            test-runner
 
       - run: just fmt-check
 
@@ -38,6 +43,11 @@ jobs:
       - uses: cargo-bins/cargo-binstall@v1.15.9
       - run: cargo binstall just
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces:
+            .
+            integration
+            test-runner
 
       - run: just clippy
 
@@ -55,6 +65,11 @@ jobs:
       - uses: cargo-bins/cargo-binstall@v1.15.9
       - run: cargo binstall just
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces:
+            .
+            integration
+            test-runner
 
       - name: Run integration tests
         run: xvfb-run just test-integrations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## wasm_split_cli v0.2.2
+
+- Add a canary import to diagnose modules getting loaded from different compilation units.
+
 ## wasm_split_helpers v0.2.2
 
 - A failed split-module load is no longer cached for the lifetime of the session

--- a/crates/magic_constants.rs
+++ b/crates/magic_constants.rs
@@ -8,6 +8,11 @@
 #[repr(u8)]
 pub enum SubsectionTag {
     Version = 1,
+    Feature = 2,
+}
+#[repr(u8)]
+pub enum FeatureTag {
+    CfgDebugAssertions = 1,
 }
 // This is a macro instead of a constant so that it can be used in #[link_section]
 macro_rules! __link_section {

--- a/crates/wasm_split/src/marker.rs
+++ b/crates/wasm_split/src/marker.rs
@@ -13,6 +13,10 @@ const fn usize_to_u32(len: usize) -> u32 {
     }
     len as u32
 }
+const fn u8_uleb(num: u8) -> u8 {
+    assert!(num < 0x80, "tag doesn't fit into byte");
+    num
+}
 const fn u32_uleb_len(num: u32) -> usize {
     // for simplicity, we encode either 1 or 5 bytes.
     match num {
@@ -24,19 +28,20 @@ const fn u32_uleb_len(num: u32) -> usize {
 const fn u32_uleb(num: u32, buffer: &mut [u8]) {
     debug_assert!(buffer.len() == u32_uleb_len(num));
     let mut rem = num;
-    let mut continue_mask: u8 = 0x00;
     const SHIFT: usize = 7;
+    let len = buffer.len();
 
-    let mut i = buffer.len();
-    while i > 0 {
-        i -= 1;
+    let mut i = 0;
+    while i < len {
         let b = &mut buffer[i];
+        i += 1;
 
         let low = (rem & 0x7f) as u8;
         rem >>= SHIFT;
+        let continue_mask = if i == len { 0x00 } else { 0x80 };
         *b = continue_mask | low;
-        continue_mask = 0x80;
     }
+    debug_assert!(rem == 0, "num should be written completely");
 }
 
 // We use a wasm-typical approach of a self-describing subsection.
@@ -59,8 +64,8 @@ macro_rules! encode_subsection {
                 let (tag_buf, buffer) = buffer.split_at_mut(1);
                 let (len_buf, payload_buffer) = buffer.split_at_mut(u32_uleb_len(_PAYLOAD_LEN));
                 const TAG: crate::marker::magic_constants::SubsectionTag = $tag;
-                tag_buf[0] = TAG as u8;
-                crate::marker::u32_uleb(_PAYLOAD_LEN, len_buf);
+                tag_buf[0] = u8_uleb(TAG as u8);
+                u32_uleb(_PAYLOAD_LEN, len_buf);
                 $encode_payload(payload_buffer);
             }
             let mut buffer = [0; _SECTION_LEN];
@@ -89,7 +94,7 @@ const VERSION: Version = Version::Version1;
 const VERSION_PAYLOAD_LEN: usize = 1;
 const fn encode_version(buffer: &mut [u8]) {
     debug_assert!(buffer.len() == VERSION_PAYLOAD_LEN);
-    buffer[0] = VERSION as u8;
+    buffer[0] = u8_uleb(VERSION as u8);
 }
 
 encode_subsection! {
@@ -104,7 +109,7 @@ const _: () = {
     const FEATURE_PAYLOAD_LEN: usize = 1;
     const fn encode_feature_debug_assertions(buffer: &mut [u8]) {
         debug_assert!(buffer.len() == FEATURE_PAYLOAD_LEN);
-        buffer[0] = FeatureTag::CfgDebugAssertions as u8;
+        buffer[0] = u8_uleb(FeatureTag::CfgDebugAssertions as u8);
     }
 
     encode_subsection! {

--- a/crates/wasm_split/src/marker.rs
+++ b/crates/wasm_split/src/marker.rs
@@ -2,7 +2,7 @@
 
 #[path = "./magic_constants.rs"]
 mod magic_constants;
-use magic_constants::{link_section, SubsectionTag, Version};
+use magic_constants::{link_section, FeatureTag, SubsectionTag, Version};
 
 const fn usize_to_u32(len: usize) -> u32 {
     // We ... don't assume usize is bigger or smaller than a u32,
@@ -50,17 +50,31 @@ const fn u32_uleb(num: u32, buffer: &mut [u8]) {
 // | tag: u8 | len: u32 as uleb | payload: [u8; len] |
 // ```
 macro_rules! encode_subsection {
-    ( const ($LEN:ident, fn $encoder:ident) = ($tag:expr, $payload_len:expr, $encode_payload:path) ; ) => {
+    ( tag: $tag:expr, len: $payload_len:expr, $encode_payload:path, $($entropy:expr),* ) => {
         const _PAYLOAD_LEN: u32 = usize_to_u32($payload_len);
-        const $LEN: usize = 1 + u32_uleb_len(_PAYLOAD_LEN) + $payload_len;
-        const fn $encoder(buffer: &mut [u8]) {
-            debug_assert!(buffer.len() == $LEN);
-            let (tag_buf, buffer) = buffer.split_at_mut(1);
-            let (len_buf, payload_buffer) = buffer.split_at_mut(u32_uleb_len(_PAYLOAD_LEN));
-            tag_buf[0] = $tag;
-            u32_uleb(_PAYLOAD_LEN, len_buf);
-            $encode_payload(payload_buffer);
-        }
+        const _SECTION_LEN: usize = 1 + u32_uleb_len(_PAYLOAD_LEN) + $payload_len;
+        const SECTION_CONTENT: [u8; _SECTION_LEN] = {
+            const fn encoder(buffer: &mut [u8]) {
+                debug_assert!(buffer.len() == _SECTION_LEN);
+                let (tag_buf, buffer) = buffer.split_at_mut(1);
+                let (len_buf, payload_buffer) = buffer.split_at_mut(u32_uleb_len(_PAYLOAD_LEN));
+                const TAG: crate::marker::magic_constants::SubsectionTag = $tag;
+                tag_buf[0] = TAG as u8;
+                crate::marker::u32_uleb(_PAYLOAD_LEN, len_buf);
+                $encode_payload(payload_buffer);
+            }
+            let mut buffer = [0; _SECTION_LEN];
+            encoder(&mut buffer);
+            buffer
+        };
+        // #[export_name] is needed so the linker doesn't remove the section. Might be replaced by #[used(linker)] in the future.
+        // See also: https://github.com/rust-lang/rust/issues/56639
+        #[unsafe(export_name = ::core::concat!(::wasm_split_macros::version_stamp!() , $($entropy),* ))]
+        static _MARKER: () = {
+            #[used]
+            #[unsafe(link_section = crate::marker::magic_constants::link_section!())]
+            static _DUMMY: [u8; _SECTION_LEN] = SECTION_CONTENT;
+        };
     };
 }
 
@@ -79,20 +93,24 @@ const fn encode_version(buffer: &mut [u8]) {
 }
 
 encode_subsection! {
-    const (VERSION_SUBSECTION_LEN, fn encode_version_subsection) = (SubsectionTag::Version as u8, VERSION_PAYLOAD_LEN, encode_version);
+    tag: SubsectionTag::Version,
+    len: VERSION_PAYLOAD_LEN,
+    encode_version,
+    "version"
 }
 
-const WASM_SPLIT_VERSION: [u8; VERSION_SUBSECTION_LEN] = {
-    let mut buffer = [0; VERSION_SUBSECTION_LEN];
-    encode_version_subsection(&mut buffer);
-    buffer
-};
+#[cfg(debug_assertions)]
+const _: () = {
+    const FEATURE_PAYLOAD_LEN: usize = 1;
+    const fn encode_feature_debug_assertions(buffer: &mut [u8]) {
+        debug_assert!(buffer.len() == FEATURE_PAYLOAD_LEN);
+        buffer[0] = FeatureTag::CfgDebugAssertions as u8;
+    }
 
-// #[no_mangle] is needed so the linker doesn't remove the section. Might be replaced by #[used(linker)] in the future.
-// See also: https://github.com/rust-lang/rust/issues/56639
-#[unsafe(export_name = wasm_split_macros::version_stamp!())]
-static _MARKER: () = {
-    #[used]
-    #[unsafe(link_section = link_section!())]
-    static _WASM_SPLIT_VERSION: [u8; VERSION_SUBSECTION_LEN] = WASM_SPLIT_VERSION;
+    encode_subsection! {
+        tag: SubsectionTag::Feature,
+        len: FEATURE_PAYLOAD_LEN,
+        encode_feature_debug_assertions,
+        "debug_asserts"
+    }
 };

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -28,13 +28,14 @@ pub(crate) struct EmitState<'a> {
     data_relocations: DataEmitInfo,
     shared_names: HashMap<DepNode, Cow<'a, str>>,
     no_reloc_stubs: HashSet<InputFuncId>,
+    canary_import_name: &'a str,
 }
 
 impl<'a> EmitState<'a> {
     pub(crate) fn new(
         input_options: &'a crate::Options<'a>,
         module: &'a InputModule<'a>,
-        program_info: &SplitProgramInfo,
+        program_info: &'a SplitProgramInfo,
         link_module: &'a str,
         no_reloc_stubs: HashSet<InputFuncId>,
     ) -> Result<Self> {
@@ -86,7 +87,12 @@ impl<'a> EmitState<'a> {
             data_relocations,
             shared_names,
             no_reloc_stubs,
+            canary_import_name: program_info.canary_export_name(),
         })
+    }
+
+    pub(crate) fn input(&self) -> &InputModule<'_> {
+        self.input_module
     }
 
     fn get_indirect_function_table_type(&self) -> wasmparser::TableType {
@@ -854,6 +860,17 @@ impl<'a> ModuleEmitState<'a> {
                 &imp.module
             };
             section.import(module, &imp.name, EntityType::try_from(imp.ty).unwrap());
+        }
+        if !self.is_main() && self.emit_state.input_module.options.debug_assertions {
+            section.import(
+                "__wasm_split",
+                self.emit_state.canary_import_name,
+                EntityType::Global(wasm_encoder::GlobalType {
+                    val_type: wasm_encoder::ValType::I32,
+                    mutable: false,
+                    shared: false,
+                }),
+            );
         }
         self.output_module.section(&section);
     }

--- a/crates/wasm_split_cli/src/js.rs
+++ b/crates/wasm_split_cli/src/js.rs
@@ -4,21 +4,29 @@ use std::{collections::HashMap, fmt::Write, path::Path};
 use crate::{
     dep_graph::DepNode,
     emit::EmitState,
+    read::InputModule,
     split_point::{OutputModuleInfo, SplitModuleIdentifier, SplitProgramInfo},
 };
 
 type PrefetchMap = HashMap<String, Vec<String>>;
-pub struct LinkModuleWriter {
+pub struct LinkModuleWriter<'p> {
+    input_module: &'p InputModule<'p>,
+    program_info: &'p SplitProgramInfo,
     javascript: String,
     prefetch_map: PrefetchMap,
 }
 
-impl LinkModuleWriter {
-    fn new() -> Self {
+impl<'p> LinkModuleWriter<'p> {
+    fn new(program_info: &'p SplitProgramInfo, emit_state: &'p EmitState) -> Self {
         Self {
+            program_info,
+            input_module: emit_state.input(),
             javascript: String::new(),
             prefetch_map: HashMap::new(),
         }
+    }
+    fn canary_name(&self) -> &str {
+        self.program_info.canary_export_name()
     }
     fn write_main_import(&mut self, mod_path: &str) -> Result<()> {
         Ok(writeln!(
@@ -28,12 +36,17 @@ impl LinkModuleWriter {
         )?)
     }
     fn write_get_shared_imports(&mut self, main_shares: &str) -> Result<()> {
+        let canary_props = if self.input_module.options.debug_assertions {
+            format!("{}: ~0xdead,", self.canary_name())
+        } else {
+            String::new()
+        };
         Ok(write!(
             &mut self.javascript,
             r#"let sharedImports = undefined;
 function getSharedImports() {{
     if (sharedImports === undefined) {{
-        sharedImports = {{ __wasm_split: {{ }} }};
+        sharedImports = {{ __wasm_split: {{ {canary_props} }} }};
         const mainExports = initSync(undefined, undefined);
         const {{ {main_shares} }} = mainExports;
         Object.assign(sharedImports.__wasm_split, {{ {main_shares} }});
@@ -47,7 +60,11 @@ function getSharedImports() {{
         self.javascript
             .push_str(include_str!("./snippets/split_wasm.js"));
         self.javascript
-            .push_str(include_str!("./snippets/makeFetch.web.js"));
+            .push_str(if self.input_module.options.debug_assertions {
+                include_str!("./snippets/makeFetch.web.debug.js")
+            } else {
+                include_str!("./snippets/makeFetch.web.js")
+            });
         Ok(())
     }
     fn write_export_const(&mut self, name: &str, def: &impl std::fmt::Display) -> Result<()> {
@@ -153,12 +170,12 @@ fn reexported_shared_symbols(
     Ok(shares)
 }
 
-pub fn link_module(
+pub fn link_module<'p>(
     main_module_path: &str,
-    program_info: &SplitProgramInfo,
-    emit_state: &EmitState,
-) -> Result<LinkModuleWriter> {
-    let mut link_module = LinkModuleWriter::new();
+    program_info: &'p SplitProgramInfo,
+    emit_state: &'p EmitState,
+) -> Result<LinkModuleWriter<'p>> {
+    let mut link_module = LinkModuleWriter::new(program_info, emit_state);
 
     let (_, main_module) = program_info
         .output_modules

--- a/crates/wasm_split_cli/src/read.rs
+++ b/crates/wasm_split_cli/src/read.rs
@@ -9,7 +9,9 @@ pub use wasmparser::{
 
 use crate::{
     dep_graph::DepNode,
-    magic_constants::{SubsectionTag as WsSubsectionTag, Version as WsVersion},
+    magic_constants::{
+        FeatureTag as WsFeature, SubsectionTag as WsSubsectionTag, Version as WsVersion,
+    },
     reloc::{RelocInfo, RelocInfoParser},
 };
 
@@ -167,6 +169,7 @@ pub struct InputModule<'a> {
     pub imported_func_map: HashMap<ImportId, InputFuncId>,
 
     pub reloc_info: RelocInfo<'a>,
+    pub options: Options,
 }
 
 pub enum Strictness {
@@ -273,7 +276,7 @@ impl<'a> InputModule<'a> {
             }
             if section.name == crate::magic_constants::LINK_SECTION {
                 let rdr = BinaryReader::new(section.data, section.data_offset);
-                let () = read_wasm_split_section(rdr)?;
+                let () = read_wasm_split_section(rdr, &mut module.options)?;
                 num_split_sections_found += 1;
             }
         }
@@ -326,8 +329,13 @@ enum WsReadVersion {
     Known(WsVersion),
     Unknown,
 }
+enum WsReadFeature {
+    Known(WsFeature),
+    Unknown,
+}
 enum WasmSplitSubsection<'a> {
     Version(WsReadVersion),
+    Feature(WsReadFeature),
     Unknown(BinaryReader<'a>),
 }
 fn read_version(reader: &mut BinaryReader<'_>) -> wasmparser::Result<WsReadVersion> {
@@ -338,6 +346,16 @@ fn read_version(reader: &mut BinaryReader<'_>) -> wasmparser::Result<WsReadVersi
         _ => WsReadVersion::Unknown,
     })
 }
+fn read_feature(reader: &mut BinaryReader<'_>) -> wasmparser::Result<WsReadFeature> {
+    let feature = reader.read_u8()?;
+    // TODO: for future version, read an uleb
+    Ok(match feature {
+        feat if feat == WsFeature::CfgDebugAssertions as u8 => {
+            WsReadFeature::Known(WsFeature::CfgDebugAssertions)
+        }
+        _ => WsReadFeature::Unknown,
+    })
+}
 
 impl<'a> Subsection<'a> for WasmSplitSubsection<'a> {
     fn from_reader(id: u8, mut reader: BinaryReader<'a>) -> wasmparser::Result<Self> {
@@ -346,12 +364,23 @@ impl<'a> Subsection<'a> for WasmSplitSubsection<'a> {
                 let version = read_version(&mut reader)?;
                 Ok(Self::Version(version))
             }
+            id if id == WsSubsectionTag::Feature as u8 => {
+                let feature = read_feature(&mut reader)?;
+                Ok(Self::Feature(feature))
+            }
             _ => Ok(Self::Unknown(reader)),
         }
     }
 }
 
-fn read_wasm_split_section(rdr: BinaryReader<'_>) -> Result<()> {
+/// Options found in the web assembly.
+// Make sure these do not depend on the order they are found in.
+#[derive(Default)]
+pub struct Options {
+    pub debug_assertions: bool,
+}
+
+fn read_wasm_split_section(rdr: BinaryReader<'_>, options: &mut Options) -> Result<()> {
     let subsections = Subsections::<WasmSplitSubsection>::new(rdr);
     for subsection in subsections {
         match subsection? {
@@ -362,6 +391,11 @@ fn read_wasm_split_section(rdr: BinaryReader<'_>) -> Result<()> {
             ),
             WasmSplitSubsection::Version(WsReadVersion::Known(WsVersion::Version1)) => {
                 // No additional information at the moment
+            }
+            // features are by design optional to detect!
+            WasmSplitSubsection::Feature(WsReadFeature::Unknown) => {}
+            WasmSplitSubsection::Feature(WsReadFeature::Known(WsFeature::CfgDebugAssertions)) => {
+                options.debug_assertions = true;
             }
             WasmSplitSubsection::Unknown(reader) => {
                 let _ = reader;

--- a/crates/wasm_split_cli/src/snippets/makeFetch.web.debug.js
+++ b/crates/wasm_split_cli/src/snippets/makeFetch.web.debug.js
@@ -1,0 +1,18 @@
+function makeFetch(srcUrl) {
+    if (srcUrl === undefined) {
+        return () => { return async (_imports) => { return {} } };
+    }
+    return () => {
+        const src = fetch(srcUrl);
+        return async (imports) => {
+            try {
+                return await WebAssembly.instantiateStreaming(src, imports);
+            } catch (e) {
+                if (e instanceof WebAssembly.LinkError && e.message.includes("__canary")) {
+                    console.error("wasm-split: It looks like you are trying to load a split module that does not belong to the same compilation unit. This is not supported.")
+                }
+                throw e;
+            }
+        }
+    }
+}

--- a/crates/wasm_split_cli/src/split_point.rs
+++ b/crates/wasm_split_cli/src/split_point.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::hash::{DefaultHasher, Hasher};
 
 use crate::dep_graph::{DepGraph, DepNode};
 use crate::graph_utils::tarjan_scc::{SccEvent, SccId, TarjanSccResult};
@@ -342,6 +343,19 @@ pub struct SplitProgramInfo {
 
     pub shared_deps: HashSet<DepNode>,
     pub symbol_output_module: HashMap<DepNode, usize>,
+    /// A pseudo-unique identifier for the input file and options.
+    /// We get better detection if this differs between compilations, but it should be derived from
+    /// the input deterministically. Options can (and should) influence this if they lead to different
+    /// output modules.
+    pub canary_export_name: String,
+}
+
+impl SplitProgramInfo {
+    /// The name of the additional import included in split modules to verify at link time that they
+    /// are loaded from the correct main module.
+    pub fn canary_export_name(&self) -> &str {
+        &self.canary_export_name
+    }
 }
 
 struct DepGraphAnalysis<'g> {
@@ -543,6 +557,14 @@ pub fn compute_split_modules(
                 .insert(symbol, output_index);
         }
     }
+
+    // This exact implementation can differ between different compilations of the CLI, specifically
+    // between rust versions. That is fine and intended.
+    let mut hasher = DefaultHasher::new();
+    hasher.write(env!("CARGO_PKG_VERSION").as_bytes()); // TODO: hasher.write_str(_) once that's stabilized
+    hasher.write(module.raw);
+    // once options impact the output module, these should be hashed too
+    program_info.canary_export_name = format!("__canary_{:x}", hasher.finish());
 
     Ok(program_info)
 }

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ test-integrations toolchain="":
     cargo ${1:+"$1"} test --target wasm32-unknown-unknown --workspace
     cargo ${1:+"$1"} test --workspace
     XCARGO_REPORT_TAG=opt cargo ${1:+"$1"} test --target wasm32-unknown-unknown --workspace --config profile.test.opt-level=3
+    XCARGO_REPORT_TAG=release cargo ${1:+"$1"} test --target wasm32-unknown-unknown --workspace
 
 test-all-integrations: (test-integrations "+stable") (test-integrations "+nightly") (test-integrations "+1.84")
 

--- a/justfile
+++ b/justfile
@@ -10,6 +10,7 @@ test-integrations toolchain="":
 test-all-integrations: (test-integrations "+stable") (test-integrations "+nightly") (test-integrations "+1.84")
 
 test-cli:
+    cargo test -p wasm_split_helpers
     cargo test -p wasm_split_cli_support --all-features
 
 all-tests: test-all-integrations test-cli

--- a/justfile
+++ b/justfile
@@ -26,5 +26,9 @@ clippy:
 semver-check:
     cargo semver-checks
 
-release-checks: fmt-check clippy all-tests semver-check
-pr-checks: fmt-check clippy all-tests
+[private]
+@clean-dir:
+    git diff --quiet HEAD || (echo >&2 "not in a clean working directory" && exit 1)
+
+release-checks: clean-dir fmt-check clippy all-tests semver-check
+pr-checks: clean-dir fmt-check clippy all-tests


### PR DESCRIPTION
By importing a unique name in the split modules, we get a `LinkError` when these splits are imported from the incorrect main module (which would most likely lead to downstream problems such as mismatching function signatures).

The canary is enabled only when the module is compiled with debug assertions enabled.