### PR TITLE
fix zero-sized symbols (__heap_base) in release builds on nightly rust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           toolchain: nightly
           components: clippy
+          targets: wasm32-unknown-unknown
       - uses: cargo-bins/cargo-binstall@v1.15.9
       - run: cargo binstall just
       - uses: Swatinem/rust-cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## wasm_split_cli v0.2.2
 
 - Add a canary import to diagnose modules getting loaded from different compilation units.
+  This is enabled when the crate is compiled with `debug_assertions` enabled. Detection
+  of this is automatic when compiling against `wasm_split_helpers >= 0.2.3`.
+- Fixed an error on nightly Rust related to zero-sized symbols past the defined data segments.
 
 ## wasm_split_helpers v0.2.2
 

--- a/crates/wasm_split/src/marker.rs
+++ b/crates/wasm_split/src/marker.rs
@@ -2,7 +2,7 @@
 
 #[path = "./magic_constants.rs"]
 mod magic_constants;
-use magic_constants::{link_section, FeatureTag, SubsectionTag, Version};
+use magic_constants::{link_section, SubsectionTag, Version};
 
 const fn usize_to_u32(len: usize) -> u32 {
     // We ... don't assume usize is bigger or smaller than a u32,
@@ -106,6 +106,8 @@ encode_subsection! {
 
 #[cfg(debug_assertions)]
 const _: () = {
+    use magic_constants::FeatureTag;
+
     const FEATURE_PAYLOAD_LEN: usize = 1;
     const fn encode_feature_debug_assertions(buffer: &mut [u8]) {
         debug_assert!(buffer.len() == FEATURE_PAYLOAD_LEN);

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -316,7 +316,10 @@ impl DataEmitInfo {
                     let address = match offset_expr.get_operators_reader().read().unwrap() {
                         wasmparser::Operator::I32Const { value } => value as usize,
                         wasmparser::Operator::I64Const { value } => value as usize,
-                        _ => return DataSegmentAnalysis::FromInputOnlyIn(0),
+                        op => {
+                            warn!("Non-constant operator {op:?} found to specify a memory's base address. Putting it into main.");
+                            return DataSegmentAnalysis::FromInputOnlyIn(0);
+                        }
                     };
                     DataSegmentAnalysis::Ranges {
                         ranges: vec![],
@@ -346,6 +349,13 @@ impl DataEmitInfo {
                             "Expected data symbol dep node to ref to defined data symbol"
                         )));
                     };
+                    if def_data.size == 0 {
+                        // We don't care about zero-sized symbols.
+                        // There are some prominent examples, specifically __heap_base, that lead to a zero-sized
+                        // data symbol in the output. For this example specifically, it sometimes leads to problems
+                        // since it is often outside the range of data defined via segments in the input.
+                        return None;
+                    }
                     let segment_index = def_data.index as usize;
                     let DataSegmentAnalysis::Ranges { .. } = &per_segment[segment_index] else {
                         // Only relocate if in active range
@@ -371,6 +381,17 @@ impl DataEmitInfo {
                 let data_len = def_data.size as usize;
                 let data_offset = def_data.offset as usize;
                 let data_range = data_offset..data_offset + data_len;
+
+                let in_segment = &input_module.data_segments[segment_index];
+                if data_range.end > in_segment.data.len() {
+                    unreachable!(
+                        "Found data symbol {:?} that extends past the input module's data \
+                        bytes: {data_range:?} not in range for data segment of length {}",
+                        input_module.reloc_info.symbols[symbol_index],
+                        in_segment.data.len()
+                    );
+                }
+
                 let segment_align =
                     1usize << input_module.reloc_info.segments[segment_index].alignment;
 
@@ -379,9 +400,8 @@ impl DataEmitInfo {
                     // TODO: .isolate_least_significant_one()
                     data_align = data_align.min(1usize << data_offset.trailing_zeros());
                 }
-                if data_len != 0 {
-                    data_align = data_align.min(1usize << data_len.trailing_zeros());
-                }
+                debug_assert!(data_len != 0, "zero-sized symbols handled previously");
+                data_align = data_align.min(1usize << data_len.trailing_zeros());
 
                 let mut has_merged = false;
                 let range_idx = ranges.len();
@@ -495,6 +515,10 @@ impl DataEmitInfo {
         symbol_index: usize,
         data: &DefinedDataSymbol,
     ) -> Option<usize> {
+        if data.size == 0 {
+            // zero-sized symbols are not relocated
+            return None;
+        }
         let segment_idx = data.index as usize;
         let DataSegmentEmitInfo::Ranges {
             ranges,

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ test-integrations toolchain="":
     cargo ${1:+"$1"} test --target wasm32-unknown-unknown --workspace
     cargo ${1:+"$1"} test --workspace
     XCARGO_REPORT_TAG=opt cargo ${1:+"$1"} test --target wasm32-unknown-unknown --workspace --config profile.test.opt-level=3
-    XCARGO_REPORT_TAG=release cargo ${1:+"$1"} test --target wasm32-unknown-unknown --workspace
+    XCARGO_REPORT_TAG=release cargo ${1:+"$1"} test --target wasm32-unknown-unknown --workspace --release
 
 test-all-integrations: (test-integrations "+stable") (test-integrations "+nightly") (test-integrations "+1.84")
 
@@ -22,6 +22,8 @@ fmt-check:
 
 clippy:
     cargo +nightly clippy -- -Dwarnings
+    cargo +nightly clippy --target wasm32-unknown-unknown -- -Dwarnings
+    cargo +nightly clippy --profile=release --target wasm32-unknown-unknown -- -Dwarnings
     cd integration && cargo +nightly clippy -- -Dwarnings
     cd test-runner && cargo +nightly clippy -- -Dwarnings
 


### PR DESCRIPTION
Zero-sized symbols such as `__heap_base` do not carry any data with them. As such, their data range can be outside of the bytes defined data segments of the files. It is currently not 100% clear if not moving these leads could lead to problems down the road. As of now, I trust that since we should only be splitting data ranges, the split ranges inherit the property of not extending into heap space from the input module.

The bug was discovered when enabling additional checks for CI. Also enabled are now:
- The marker file was previously not covered with clippy due to being conditional on wasm target.
- The feature marker was not covered with clippy due to being conditional on debug_assertions.