### PR TITLE
Fix functions reachable through static mut

### DIFF
--- a/crates/magic_constants.rs
+++ b/crates/magic_constants.rs
@@ -29,3 +29,7 @@ pub enum Version {
 }
 
 pub const PLACEHOLDER_IMPORT_MODULE: &str = "__wasm_split_placeholder__";
+// see the version_stamp! macro why we need to emit additional (zero-sized) exported
+// symbols to emit bytes into our custom data section. These symbols are excluded
+// from the list of exported globals in the cli (and might not be needed in the future).
+pub const GLOBAL_WASM_SPLIT_MARKER: &str = "_WASM_SPLIT_MARKER_";

--- a/crates/wasm_split_cli/src/dep_graph.rs
+++ b/crates/wasm_split_cli/src/dep_graph.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use eyre::{anyhow, bail, Result};
-use wasmparser::{FunctionBody, Operator, RelocationEntry};
+use wasmparser::{Export, ExternalKind, FunctionBody, Operator, RelocationEntry, SymbolInfo};
 
 use crate::{
     read::{GlobalId, InputFuncId, InputModule, MemoryId, SymbolIndex, TableId, TagId},
@@ -24,7 +24,14 @@ pub enum DepNode {
 
 pub type DepGraph = HashMap<DepNode, HashSet<DepNode>>;
 
-pub fn get_dependencies(module: &InputModule) -> Result<(DepGraph, HashSet<InputFuncId>)> {
+pub struct Dependencies {
+    pub graph: DepGraph,
+    pub stub_fns: HashSet<InputFuncId>,
+    // `#i -> #s` if Global #i contains the address of symbol #s
+    pub symbol_as_global: HashMap<GlobalId, SymbolIndex>,
+}
+
+pub fn get_dependencies(module: &InputModule) -> Result<Dependencies> {
     struct Builder<'a, 'm>(DepGraph, &'a InputModule<'m>);
     impl Builder<'_, '_> {
         fn add_dep(&mut self, a: DepNode, b: DepNode) {
@@ -122,7 +129,82 @@ pub fn get_dependencies(module: &InputModule) -> Result<(DepGraph, HashSet<Input
             }
         }
     }
-    Ok((deps.0, stub_fns))
+
+    let mut symbol_as_global = HashMap::new();
+    for &export in &module.exports {
+        let Export {
+            kind: ExternalKind::Global,
+            index: global_index,
+            name: global_name,
+        } = export
+        else {
+            continue;
+        };
+        // You would think that there is reloc data available that tells us which symbols are exported
+        // but there is not. The flags also do not tell us this information (which might be a bug in the
+        // way symbol information is emitted). In any case, we reconstruct this information.
+        let Some((symbol_index, symbol)) =
+            module
+                .reloc_info
+                .symbols
+                .iter()
+                .enumerate()
+                .find(|(_, &info)| {
+                    let SymbolInfo::Data {
+                        flags: _,
+                        name: symbol_name,
+                        symbol: _,
+                    } = info
+                    else {
+                        return false;
+                    };
+                    symbol_name == global_name
+                })
+        else {
+            continue;
+        };
+        tracing::trace!(
+            "Recovered global symbol {global_index} mapping to {symbol_index} [{symbol:?}]"
+        );
+        #[cfg(debug_assertions)]
+        {
+            use wasmparser::ValType;
+
+            let global = &module.globals[global_index as usize];
+            assert!(
+                matches!(global.ty.content_type, ValType::I32 | ValType::I64),
+                "expected be a memory address"
+            );
+            assert!(
+                !global.ty.mutable && !global.ty.shared,
+                "a memory address should be immutable and not shared"
+            );
+            let _addr: usize = match global.init_expr.get_operators_reader().read() {
+                Ok(Operator::I32Const { value }) => {
+                    usize::try_from(value).expect("a valid address should fit into a usize")
+                }
+                Ok(Operator::I64Const { value }) => {
+                    usize::try_from(value).expect("a valid address should fit into a usize")
+                }
+                _ => unreachable!(
+                    "expected a constant initializer expression for an exported data symbol"
+                ),
+            };
+            // could decode the symbol's address from the data-segment base address here too. Trust that this is correct
+        }
+        deps.add_dep(
+            DepNode::Global(global_index as usize),
+            DepNode::DataSymbol(symbol_index),
+        );
+        symbol_as_global.insert(global_index, symbol_index);
+    }
+
+    // Global symbols exporting the memory address of a symbol depend on that symbols
+    Ok(Dependencies {
+        graph: deps.0,
+        stub_fns,
+        symbol_as_global: HashMap::new(),
+    })
 }
 
 fn iter_functions_with_relocs<'m>(

--- a/crates/wasm_split_cli/src/dep_graph.rs
+++ b/crates/wasm_split_cli/src/dep_graph.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use eyre::{anyhow, bail, Result};
-use wasmparser::{Export, ExternalKind, FunctionBody, Operator, RelocationEntry, SymbolInfo};
+use wasmparser::{FunctionBody, Operator, RelocationEntry};
 
 use crate::{
     read::{GlobalId, InputFuncId, InputModule, MemoryId, SymbolIndex, TableId, TagId},
@@ -27,8 +27,6 @@ pub type DepGraph = HashMap<DepNode, HashSet<DepNode>>;
 pub struct Dependencies {
     pub graph: DepGraph,
     pub stub_fns: HashSet<InputFuncId>,
-    // `#i -> #s` if Global #i contains the address of symbol #s
-    pub symbol_as_global: HashMap<GlobalId, SymbolIndex>,
 }
 
 pub fn get_dependencies(module: &InputModule) -> Result<Dependencies> {
@@ -130,80 +128,17 @@ pub fn get_dependencies(module: &InputModule) -> Result<Dependencies> {
         }
     }
 
-    let mut symbol_as_global = HashMap::new();
-    for &export in &module.exports {
-        let Export {
-            kind: ExternalKind::Global,
-            index: global_index,
-            name: global_name,
-        } = export
-        else {
-            continue;
-        };
-        // You would think that there is reloc data available that tells us which symbols are exported
-        // but there is not. The flags also do not tell us this information (which might be a bug in the
-        // way symbol information is emitted). In any case, we reconstruct this information.
-        let Some((symbol_index, symbol)) =
-            module
-                .reloc_info
-                .symbols
-                .iter()
-                .enumerate()
-                .find(|(_, &info)| {
-                    let SymbolInfo::Data {
-                        flags: _,
-                        name: symbol_name,
-                        symbol: _,
-                    } = info
-                    else {
-                        return false;
-                    };
-                    symbol_name == global_name
-                })
-        else {
-            continue;
-        };
-        tracing::trace!(
-            "Recovered global symbol {global_index} mapping to {symbol_index} [{symbol:?}]"
-        );
-        #[cfg(debug_assertions)]
-        {
-            use wasmparser::ValType;
-
-            let global = &module.globals[global_index as usize];
-            assert!(
-                matches!(global.ty.content_type, ValType::I32 | ValType::I64),
-                "expected be a memory address"
-            );
-            assert!(
-                !global.ty.mutable && !global.ty.shared,
-                "a memory address should be immutable and not shared"
-            );
-            let _addr: usize = match global.init_expr.get_operators_reader().read() {
-                Ok(Operator::I32Const { value }) => {
-                    usize::try_from(value).expect("a valid address should fit into a usize")
-                }
-                Ok(Operator::I64Const { value }) => {
-                    usize::try_from(value).expect("a valid address should fit into a usize")
-                }
-                _ => unreachable!(
-                    "expected a constant initializer expression for an exported data symbol"
-                ),
-            };
-            // could decode the symbol's address from the data-segment base address here too. Trust that this is correct
-        }
+    for (&global_index, &symbol_index) in &module.reloc_info.symbol_as_global {
         deps.add_dep(
-            DepNode::Global(global_index as usize),
+            DepNode::Global(global_index),
             DepNode::DataSymbol(symbol_index),
         );
-        symbol_as_global.insert(global_index, symbol_index);
     }
 
     // Global symbols exporting the memory address of a symbol depend on that symbols
     Ok(Dependencies {
         graph: deps.0,
         stub_fns,
-        symbol_as_global: HashMap::new(),
     })
 }
 

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     dep_graph::DepNode,
     magic_constants,
-    read::{GlobalId, InputFuncId, InputModule, InputOffset, SymbolIndex},
+    read::{InputFuncId, InputModule, InputOffset},
     reloc::{RelocDetails, RelocInfo, RelocTarget},
     split_point::{SplitModuleIdentifier, SplitProgramInfo},
 };
@@ -28,7 +28,6 @@ pub(crate) struct EmitState<'a> {
     data_relocations: DataEmitInfo,
     shared_names: HashMap<DepNode, Cow<'a, str>>,
     no_reloc_stubs: &'a HashSet<InputFuncId>,
-    global_symbols: &'a HashMap<GlobalId, SymbolIndex>,
     canary_import_name: &'a str,
 }
 
@@ -39,7 +38,6 @@ impl<'a> EmitState<'a> {
         program_info: &'a SplitProgramInfo,
         link_module: &'a str,
         no_reloc_stubs: &'a HashSet<InputFuncId>,
-        global_symbols: &'a HashMap<GlobalId, SymbolIndex>,
     ) -> Result<Self> {
         let indirect_functions = IndirectFunctionEmitInfo::new(module, program_info)?;
         let data_relocations = DataEmitInfo::new(module, program_info)?;
@@ -89,7 +87,6 @@ impl<'a> EmitState<'a> {
             data_relocations,
             shared_names,
             no_reloc_stubs,
-            global_symbols,
             canary_import_name: program_info.canary_export_name(),
         })
     }
@@ -941,7 +938,13 @@ impl<'a> ModuleEmitState<'a> {
         for (global_idx, global) in self.input_module.globals.iter().enumerate() {
             let global_expr = global.init_expr.clone();
             let mut init_expr = global_expr.clone().try_into().unwrap();
-            if let Some(&symbol) = self.emit_state.global_symbols.get(&global_idx) {
+            if let Some(&symbol) = self
+                .emit_state
+                .input_module
+                .reloc_info
+                .symbol_as_global
+                .get(&global_idx)
+            {
                 let (reloc_type, conv_reloc_value): (RelocationType, fn(usize) -> ConstExpr) =
                     match global_expr.get_operators_reader().read() {
                         Ok(Operator::I32Const { value: _ }) => {

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -7,16 +7,16 @@ use std::{
 use crate::{
     dep_graph::DepNode,
     magic_constants,
-    read::{InputFuncId, InputModule, InputOffset},
+    read::{GlobalId, InputFuncId, InputModule, InputOffset, SymbolIndex},
     reloc::{RelocDetails, RelocInfo, RelocTarget},
     split_point::{SplitModuleIdentifier, SplitProgramInfo},
 };
 use eyre::{anyhow, bail, Context, Result};
 use tracing::{trace, warn};
-use wasm_encoder::{reencode::Reencode, EntityType, ProducersField, ProducersSection};
+use wasm_encoder::{reencode::Reencode, ConstExpr, EntityType, ProducersField, ProducersSection};
 use wasmparser::{
-    BinaryReader, Data, DataKind, DefinedDataSymbol, ExternalKind, ProducersSectionReader,
-    SegmentFlags, SymbolInfo, TypeRef,
+    BinaryReader, Data, DataKind, DefinedDataSymbol, ExternalKind, Operator,
+    ProducersSectionReader, RelocationType, SegmentFlags, SymbolInfo, TypeRef,
 };
 
 pub(crate) struct EmitState<'a> {
@@ -27,7 +27,8 @@ pub(crate) struct EmitState<'a> {
     indirect_functions: IndirectFunctionEmitInfo,
     data_relocations: DataEmitInfo,
     shared_names: HashMap<DepNode, Cow<'a, str>>,
-    no_reloc_stubs: HashSet<InputFuncId>,
+    no_reloc_stubs: &'a HashSet<InputFuncId>,
+    global_symbols: &'a HashMap<GlobalId, SymbolIndex>,
     canary_import_name: &'a str,
 }
 
@@ -37,7 +38,8 @@ impl<'a> EmitState<'a> {
         module: &'a InputModule<'a>,
         program_info: &'a SplitProgramInfo,
         link_module: &'a str,
-        no_reloc_stubs: HashSet<InputFuncId>,
+        no_reloc_stubs: &'a HashSet<InputFuncId>,
+        global_symbols: &'a HashMap<GlobalId, SymbolIndex>,
     ) -> Result<Self> {
         let indirect_functions = IndirectFunctionEmitInfo::new(module, program_info)?;
         let data_relocations = DataEmitInfo::new(module, program_info)?;
@@ -87,6 +89,7 @@ impl<'a> EmitState<'a> {
             data_relocations,
             shared_names,
             no_reloc_stubs,
+            global_symbols,
             canary_import_name: program_info.canary_export_name(),
         })
     }
@@ -606,16 +609,17 @@ impl RelocTarget for ModuleEmitState<'_> {
                     .emit_state
                     .indirect_functions
                     .function_table_index
-                    .get(&input_func_id)
-                    .ok_or_else(|| {
-                        anyhow!(
-                            "Dependency analysis error: \
-                             No indirect function table index \
-                             for input function {input_func_id} \
-                             referenced by relocation."
-                        )
-                    })?;
-                Ok(Some(*index))
+                    .get(&input_func_id);
+                // in some cases, we fallback to emitting the whole module's data in the main module
+                // in these cases, some data symbols reference functions that we found to be unreachable
+                // these do not get an index in the emitted function table. We rewrite them to the
+                // index 0, which will trap when executed.
+                // no other relocations are expected against data segments.
+                let index = index.cloned().unwrap_or(0);
+                // TODO: we could assert that we are indeed relocating a data segment here.
+                // an improved analysis of data segments could perhaps avoid this case entirely
+                // and restore the assertion that the referenced function is reachable.
+                Ok(Some(index))
             }
             RelocDetails::RelTableIndex(_details) => {
                 bail!("Unsupported relocation type: relative table index")
@@ -846,7 +850,7 @@ impl<'a> ModuleEmitState<'a> {
         self.generate_function_section();
         self.generate_table_section();
         self.generate_memory_section();
-        self.generate_global_section();
+        self.generate_global_section()?;
         self.generate_export_section();
         self.generate_start_section();
         self.generate_element_section()?;
@@ -929,18 +933,53 @@ impl<'a> ModuleEmitState<'a> {
         self.output_module.section(&section);
     }
 
-    fn generate_global_section(&mut self) {
+    fn generate_global_section(&mut self) -> Result<()> {
         if !self.is_main() {
-            return;
+            return Ok(());
         }
         let mut section = wasm_encoder::GlobalSection::new();
-        for global in self.input_module.globals.iter() {
-            section.global(
-                global.ty.try_into().unwrap(),
-                &global.init_expr.clone().try_into().unwrap(),
-            );
+        for (global_idx, global) in self.input_module.globals.iter().enumerate() {
+            let global_expr = global.init_expr.clone();
+            let mut init_expr = global_expr.clone().try_into().unwrap();
+            if let Some(&symbol) = self.emit_state.global_symbols.get(&global_idx) {
+                let (reloc_type, conv_reloc_value): (RelocationType, fn(usize) -> ConstExpr) =
+                    match global_expr.get_operators_reader().read() {
+                        Ok(Operator::I32Const { value: _ }) => {
+                            (RelocationType::MemoryAddrI32, |val: usize| {
+                                ConstExpr::i32_const(val.try_into().unwrap())
+                            })
+                        }
+                        Ok(Operator::I64Const { value: _ }) => {
+                            (RelocationType::MemoryAddrI64, |val: usize| {
+                                ConstExpr::i64_const(val.try_into().unwrap())
+                            })
+                        }
+                        _ => {
+                            bail!("Expected a i32/i64.const expression for an exported data symbol")
+                        }
+                    };
+                let fake_reloc = wasmparser::RelocationEntry {
+                    ty: reloc_type,
+                    offset: 0,
+                    index: symbol as u32,
+                    addend: 0,
+                };
+                let details = self
+                    .emit_state
+                    .input_module
+                    .reloc_info
+                    .expand_relocation(&fake_reloc)
+                    .expect("fake reloc to look good");
+                if let Some(resolved_addr) =
+                    self.reloc_value(details).expect("to resolve an address")
+                {
+                    init_expr = conv_reloc_value(resolved_addr);
+                }
+            }
+            section.global(global.ty.try_into().unwrap(), &init_expr);
         }
         self.output_module.section(&section);
+        Ok(())
     }
 
     fn generate_export_section(&mut self) {

--- a/crates/wasm_split_cli/src/lib.rs
+++ b/crates/wasm_split_cli/src/lib.rs
@@ -99,7 +99,6 @@ pub fn transform(opts: Options) -> Result<SplitWasm> {
         &split_program_info,
         link_module,
         &deps.stub_fns,
-        &deps.symbol_as_global,
     )?;
     let wasm_modules = emit::emit_modules(
         &split_program_info,

--- a/crates/wasm_split_cli/src/lib.rs
+++ b/crates/wasm_split_cli/src/lib.rs
@@ -81,9 +81,10 @@ pub fn transform(opts: Options) -> Result<SplitWasm> {
         module.reloc_info.print_relocs();
     }
     // (2) dependency analysis and decide on splits
-    let (dep_graph, reloc_stub_fns) = dep_graph::get_dependencies(&module)?;
+    let deps = dep_graph::get_dependencies(&module)?;
     let split_points = split_point::get_split_points(&module)?;
-    let split_program_info = split_point::compute_split_modules(&module, &dep_graph, split_points)?;
+    let split_program_info =
+        split_point::compute_split_modules(&module, &deps.graph, split_points)?;
 
     if split_point::trace_enabled(opts.verbose) {
         for (name, split_deps) in split_program_info.output_modules.iter() {
@@ -97,7 +98,8 @@ pub fn transform(opts: Options) -> Result<SplitWasm> {
         &module,
         &split_program_info,
         link_module,
-        reloc_stub_fns,
+        &deps.stub_fns,
+        &deps.symbol_as_global,
     )?;
     let wasm_modules = emit::emit_modules(
         &split_program_info,

--- a/crates/wasm_split_cli/src/reloc.rs
+++ b/crates/wasm_split_cli/src/reloc.rs
@@ -6,9 +6,9 @@ use std::{
 use eyre::{anyhow, bail, Result};
 use tracing::trace;
 use wasmparser::{
-    BinaryReader, CustomSectionReader, Data, DefinedDataSymbol, ElementItems, ElementKind, Linking,
-    LinkingSectionReader, Payload, RelocAddendKind, RelocSectionReader, RelocationEntry,
-    RelocationType, Segment, SymbolFlags, SymbolInfo,
+    BinaryReader, CustomSectionReader, Data, DefinedDataSymbol, ElementItems, ElementKind, Export,
+    ExternalKind, Linking, LinkingSectionReader, Payload, RelocAddendKind, RelocSectionReader,
+    RelocationEntry, RelocationType, Segment, SymbolFlags, SymbolInfo,
 };
 
 use crate::{
@@ -102,6 +102,8 @@ impl<'a> RelocInfoParser<'a> {
         };
         info.indirect_table = indirect_function_table;
         get_indirect_functions(&mut info, indirect_function_table, module)?;
+        reconstruct_global_symbols(&mut info, &module)?;
+        tracing::error!("{:?}", info.symbol_as_global);
         Ok(info)
     }
 }
@@ -213,6 +215,80 @@ fn get_data_symbols(data_segments: &[Data], symbols: &[SymbolInfo]) -> Result<Ve
     Ok(data_symbols)
 }
 
+fn reconstruct_global_symbols(reloc_info: &mut RelocInfo<'_>, module: &InputModule) -> Result<()> {
+    let symbol_as_global = &mut reloc_info.symbol_as_global;
+    debug_assert!(
+        symbol_as_global.is_empty(),
+        "should not yet contain reconstructed data"
+    );
+    for &export in &module.exports {
+        let Export {
+            kind: ExternalKind::Global,
+            index: global_index,
+            name: global_name,
+        } = export
+        else {
+            continue;
+        };
+        // You would think that there is reloc data available that tells us which symbols are exported
+        // but there is not. The flags also do not tell us this information (which might be a bug in the
+        // way symbol information is emitted). In any case, we reconstruct this information.
+        let Some((symbol_index, symbol)) =
+            reloc_info
+                .symbols
+                .iter()
+                .enumerate()
+                .find(|(_, &symbol_info)| {
+                    let SymbolInfo::Data {
+                        flags: _,
+                        name: symbol_name,
+                        symbol: _,
+                    } = symbol_info
+                    else {
+                        return false;
+                    };
+                    symbol_name == global_name
+                })
+        else {
+            continue;
+        };
+        let global_index: GlobalId = global_index.try_into().unwrap();
+        tracing::trace!(
+            "Recovered global symbol {global_index} mapping to {symbol_index} [{symbol:?}]"
+        );
+        #[cfg(debug_assertions)]
+        {
+            use eyre::ensure;
+            use eyre::Context;
+            use wasmparser::{Operator, ValType};
+
+            let global = &module.globals[global_index];
+            ensure!(
+                matches!(global.ty.content_type, ValType::I32 | ValType::I64),
+                "expected be a memory address"
+            );
+            ensure!(
+                !global.ty.mutable && !global.ty.shared,
+                "a memory address should be immutable and not shared"
+            );
+            let _addr: usize = match global.init_expr.get_operators_reader().read() {
+                Ok(Operator::I32Const { value }) => {
+                    usize::try_from(value).context("a valid address should fit into a usize")?
+                }
+                Ok(Operator::I64Const { value }) => {
+                    usize::try_from(value).context("a valid address should fit into a usize")?
+                }
+                _ => {
+                    bail!("expected a constant initializer expression for an exported data symbol")
+                }
+            };
+            // could decode the symbol's address from the data-segment base address here too. Trust that this is correct
+        }
+        symbol_as_global.insert(global_index, symbol_index);
+    }
+    Ok(())
+}
+
 #[derive(Default)]
 pub struct RelocInfo<'a> {
     pub section_ranges: Vec<Range<InputOffset>>,
@@ -228,6 +304,8 @@ pub struct RelocInfo<'a> {
     pub stack_pointer: GlobalId,
     pub visible_indirects: HashSet<InputFuncId>,
     pub referenced_indirects: HashSet<InputFuncId>,
+    // `#i -> #s` if Global #i contains the address of symbol #s
+    pub symbol_as_global: HashMap<GlobalId, SymbolIndex>,
 }
 
 impl RelocInfo<'_> {

--- a/crates/wasm_split_cli/src/reloc.rs
+++ b/crates/wasm_split_cli/src/reloc.rs
@@ -12,6 +12,7 @@ use wasmparser::{
 };
 
 use crate::{
+    magic_constants,
     read::{GlobalId, InputFuncId, InputModule, InputOffset, TableId, TagId},
     util::{find_subrange, shift_range},
 };
@@ -102,8 +103,7 @@ impl<'a> RelocInfoParser<'a> {
         };
         info.indirect_table = indirect_function_table;
         get_indirect_functions(&mut info, indirect_function_table, module)?;
-        reconstruct_global_symbols(&mut info, &module)?;
-        tracing::error!("{:?}", info.symbol_as_global);
+        reconstruct_global_symbols(&mut info, module)?;
         Ok(info)
     }
 }
@@ -253,6 +253,20 @@ fn reconstruct_global_symbols(reloc_info: &mut RelocInfo<'_>, module: &InputModu
             continue;
         };
         let global_index: GlobalId = global_index.try_into().unwrap();
+        if global_name.starts_with(magic_constants::GLOBAL_WASM_SPLIT_MARKER) {
+            // let's try to be conservative and double check that the marker symbol is zero-sized data
+            match *symbol {
+                SymbolInfo::Data {
+                    symbol: Some(symbol),
+                    ..
+                } if symbol.size == 0 => {
+                    reloc_info.split_marker_globals.insert(global_index);
+                    continue;
+                }
+                SymbolInfo::Data { .. } => tracing::warn!("expected zero sized marker export"),
+                _ => tracing::warn!("expected wasm split marker export to export a data symbol"),
+            }
+        }
         tracing::trace!(
             "Recovered global symbol {global_index} mapping to {symbol_index} [{symbol:?}]"
         );
@@ -306,6 +320,7 @@ pub struct RelocInfo<'a> {
     pub referenced_indirects: HashSet<InputFuncId>,
     // `#i -> #s` if Global #i contains the address of symbol #s
     pub symbol_as_global: HashMap<GlobalId, SymbolIndex>,
+    pub split_marker_globals: HashSet<GlobalId>,
 }
 
 impl RelocInfo<'_> {

--- a/crates/wasm_split_cli/src/split_point.rs
+++ b/crates/wasm_split_cli/src/split_point.rs
@@ -194,6 +194,14 @@ fn get_main_module_roots(module: &InputModule, split_points: &[SplitPoint]) -> H
                 DepNode::Function(*index as usize)
             }
             wasmparser::ExternalKind::Table => DepNode::Table(*index as usize),
+            wasmparser::ExternalKind::Global
+                if module
+                    .reloc_info
+                    .split_marker_globals
+                    .contains(&(*index as usize)) =>
+            {
+                continue
+            }
             wasmparser::ExternalKind::Global => DepNode::Global(*index as usize),
             wasmparser::ExternalKind::Tag => DepNode::Tag(*index as usize),
             wasmparser::ExternalKind::Memory => DepNode::Memory(*index as usize),

--- a/crates/wasm_split_macros/src/lib.rs
+++ b/crates/wasm_split_macros/src/lib.rs
@@ -403,7 +403,11 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
 pub fn version_stamp(_args: TokenStream) -> TokenStream {
     let unique_path = std::env::var_os("CARGO_MANIFEST_PATH").unwrap();
     let unique_id = base16::encode_lower(&sha2::Sha256::digest(unique_path.as_encoded_bytes()));
-    let id = format!("_WASM_SPLIT_MARKER_{}", &unique_id[0..16]);
+    let id = format!(
+        "{}{}",
+        magic_constants::GLOBAL_WASM_SPLIT_MARKER,
+        &unique_id[0..16]
+    );
     let id = syn::LitStr::new(&id, Span::call_site().into());
     quote! { #id }.into()
 }

--- a/integration/Cargo.lock
+++ b/integration/Cargo.lock
@@ -358,6 +358,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "static_mut"
+version = "0.1.0"
+dependencies = [
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "wasm_split_helpers",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -6,7 +6,8 @@ members = [
     "simple",
     "many_shares",
     "callback-in-split",
-    "optimize_splits"
+    "optimize_splits",
+    "static_mut",
 ]
 resolver = "2"
 

--- a/integration/static_mut/Cargo.toml
+++ b/integration/static_mut/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "static_mut"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen.workspace = true
+wasm_split_helpers.workspace = true
+
+[dev-dependencies]
+wasm-bindgen-test.workspace = true
+

--- a/integration/static_mut/src/lib.rs
+++ b/integration/static_mut/src/lib.rs
@@ -1,0 +1,46 @@
+//! This test case is a bit brittle as we try to force a specific case in the analysis,
+//! specifically we target the branch when we detect an "overlong segment" and force data to
+//! be put into the main module.
+//! We then have a static item (PUB_TEST_FN) that references a dead function and which
+//! itself is unreachable. This will have to be relocated but is not reachable from any
+//! of the output functions.
+
+fn reachable_from_env() -> u32 {
+    42
+}
+
+#[no_mangle]
+pub static mut PUB_TEST_FN: fn() -> u32 = reachable_from_env;
+
+#[cfg(test)]
+mod tests {
+    use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[wasm_bindgen(inline_js = r#"
+        export function call_static_mut(inst) {
+            var exports = inst.exports;
+            var mem = new DataView(exports.memory.buffer);
+            var fn_idx = mem.getInt32(exports.PUB_TEST_FN, true);
+            var f = exports.__indirect_function_table.get(fn_idx);
+            return f();
+        }
+    "#)]
+    extern "C" {
+        fn call_static_mut(fun: &JsValue) -> u32;
+    }
+
+    // This pulls in the magic marker which we assert in all tests
+    const _: () = {
+        let _ = wasm_split_helpers::rt::ensure_loaded;
+    };
+
+    #[test]
+    fn call_through_abi() {
+        let result = call_static_mut(&wasm_bindgen::instance());
+        assert_eq!(
+            result, 42,
+            "can call symbol exposed through no_mangle static mut"
+        );
+    }
+}

--- a/integration/static_mut/src/lib.rs
+++ b/integration/static_mut/src/lib.rs
@@ -1,9 +1,6 @@
-//! This test case is a bit brittle as we try to force a specific case in the analysis,
-//! specifically we target the branch when we detect an "overlong segment" and force data to
-//! be put into the main module.
-//! We then have a static item (PUB_TEST_FN) that references a dead function and which
-//! itself is unreachable. This will have to be relocated but is not reachable from any
-//! of the output functions.
+//! We construct a static item (PUB_TEST_FN) that references a "dead" function and which
+//! itself is unreachable from inside the module. It is never-the-less publically exposed
+//! to the javascript host, and can thus be called via its address.
 
 fn reachable_from_env() -> u32 {
     42
@@ -27,7 +24,7 @@ mod tests {
         }
     "#)]
     extern "C" {
-        fn call_static_mut(fun: &JsValue) -> u32;
+        fn call_static_mut(instance: &JsValue) -> u32;
     }
 
     // This pulls in the magic marker which we assert in all tests


### PR DESCRIPTION
Exported data symbols are exposed as globals containing the address of that data symbol. There are currently no relocations emitted for the global initializers. Hence, the dependency graph didn't detect that these symbols would be reachable and that their initializer expression had to be relocated.

Fixes #38 here such an exposed data symbol is introduced in wasm-bindgen (__abort_handler and __instance_terminated).