### PR TITLE
Encode output modules in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +199,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
@@ -418,6 +449,26 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "regex"
@@ -719,6 +770,7 @@ dependencies = [
  "eyre",
  "gimli",
  "lazy_static",
+ "rayon",
  "regex",
  "tempfile",
  "tracing",

--- a/crates/wasm_split_cli/Cargo.toml
+++ b/crates/wasm_split_cli/Cargo.toml
@@ -14,6 +14,7 @@ eyre = "0.6"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 lazy_static = "1.4"
 regex = "1.12"
+rayon = "1"
 wasm-encoder = { version = "0.257", features = ["wasmparser"] }
 wasmparser = "0.257"
 # bin-only depdencies

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -1601,13 +1601,18 @@ impl wasm_encoder::reencode::Reencode for FuncReencoder<'_> {
     }
 }
 
-pub fn emit_modules<'info, M>(
+/// Encodes every output module. The modules are independent, so they are
+/// encoded in parallel; the returned vector keeps the `output_modules` order.
+pub fn emit_modules<'info, M: Send>(
     program_info: &'info SplitProgramInfo,
     emit_state: &EmitState,
-    emit_fn: impl Fn(usize, &'info SplitModuleIdentifier, Vec<u8>) -> M,
+    emit_fn: impl Fn(usize, &'info SplitModuleIdentifier, Vec<u8>) -> M + Sync,
 ) -> Result<Vec<M>> {
-    let modules = program_info.output_modules.iter().enumerate();
-    modules
+    use rayon::prelude::*;
+    let modules: Result<Vec<Option<M>>> = program_info
+        .output_modules
+        .par_iter()
+        .enumerate()
         .map(|(output_module_index, (identifier, module))| {
             if module.is_empty {
                 return Ok(None);
@@ -1625,6 +1630,6 @@ pub fn emit_modules<'info, M>(
                 emit_state.output_module.finish(),
             )))
         })
-        .filter_map(|res| res.transpose())
-        .collect()
+        .collect();
+    Ok(modules?.into_iter().flatten().collect())
 }

--- a/crates/wasm_split_cli/src/reloc.rs
+++ b/crates/wasm_split_cli/src/reloc.rs
@@ -1,5 +1,4 @@
 use std::{
-    cell::OnceCell,
     collections::{HashMap, HashSet},
     ops::Range,
 };
@@ -333,7 +332,7 @@ pub struct RelocInfo<'a> {
     pub relocatable_ranges: Vec<Range<InputOffset>>,
     pub segments: Vec<Segment<'a>>,
     pub custom_sections: HashSet<SectionId>,
-    invalid_reloc_warn: OnceCell<()>,
+    invalid_reloc_warn: std::sync::OnceLock<()>,
 
     pub code_section_index: SectionIndex,
     pub data_section_index: SectionIndex,


### PR DESCRIPTION
## Problem

`emit_modules` encodes every output module serially. On large inputs this phase dominates the whole transform: on a 2.39 GB module with 6,720 output modules (a large Leptos application, split via cargo-leptos), the phase timings are

| phase | time |
|---|---|
| parse | 1.3 s |
| dependency graph + split modules | 19.3 s |
| emit state | 1.9 s |
| **encode output modules** | **46.0 s** |
| write output | 2.1 s |

## Change

The output modules are independent — each `ModuleEmitState` borrows the shared `EmitState` immutably and encodes only its own module — so encode them with a rayon parallel iterator. The indexed collect keeps the `output_modules` order. `RelocInfo`'s warn-once `invalid_reloc_warn` cell becomes a `std::sync::OnceLock` so the borrowed state is `Sync`; the warning still fires once.

On the module above the encoding phase drops from 46.0 s to 2.8 s and the whole transform from 72 s to 29 s (384-core host; smaller hosts gain proportionally to core count).

## Verification

- `cargo test --workspace` in `integration/` (host leg) passes; I could not run the browser-mode wasm leg locally, so CI is the authority there.
- Functional equivalence on the 2.39 GB module: every emitted module passes `wasm-tools validate`, and `wasm-bindgen` 0.2.127 accepts the emitted main module.
- A byte-for-byte comparison is not meaningful for this: two identical *serial* runs already emit differing bytes run-to-run (hash-map iteration order) — 6,024 of 6,722 outputs differ between two unpatched runs. If deterministic output is a goal I am happy to look at that separately.
