### PR TITLE
fix(cli): relocate data into split modules in optimized builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   Bytes shared between modules are now emitted once, from the main module, keeping the
   alignment of every symbol in them, and the per-module parts of a segment are only padded
   to the alignment they actually need.
+- Fix relocations inside a data symbol that is contained in another symbol being attributed to
+  the containing symbol. A module that only used the inner symbol could miss the relocation's
+  target. This was hidden by the whole-segment fallback above.
 
 ## wasm-split-cli v0.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
   deduplicates and tail-merges strings, so several data symbols can share bytes. When such
   symbols were needed by different output modules, the bytes were copied once per module,
   the segment grew past its input and the whole segment was kept in the main module.
-  Bytes shared between modules are now emitted once, from the main module, keeping the
-  alignment of every symbol in them, and the per-module parts of a segment are only padded
-  to the alignment they actually need.
+  Bytes shared between modules are now emitted once, from the chunk shared by all splits that
+  need them or from the main module, keeping the alignment of every symbol in them, and the
+  per-module parts of a segment are only padded to the alignment they actually need.
 - Fix relocations inside a data symbol that is contained in another symbol being attributed to
   the containing symbol. A module that only used the inner symbol could miss the relocation's
   target. This was hidden by the whole-segment fallback above.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@
   the segment grew past its input and the whole segment was kept in the main module.
   Bytes shared between modules are now emitted once, from the chunk shared by all splits that
   need them or from the main module, keeping the alignment of every symbol in them, and the
-  per-module parts of a segment are only padded to the alignment they actually need. If a
-  relocated segment still does not fit its input, the data of the smallest modules is moved
-  into the main module instead of giving up on the whole segment.
+  data of all modules is placed by decreasing alignment, so that ordinary data needs no
+  padding. Each module emits one data segment per run of its data, typically one per alignment
+  it uses; the input's data segments keep their indices and the additional segments are
+  appended. If a relocated segment still does not fit its input, the data of the smallest
+  modules is moved into the main module instead of giving up on the whole segment, and this
+  is reported at info level.
 - Fix relocations inside a data symbol that is contained in another symbol being attributed to
   the containing symbol. A module that only used the inner symbol could miss the relocation's
   target. This was hidden by the whole-segment fallback above.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
   the segment grew past its input and the whole segment was kept in the main module.
   Bytes shared between modules are now emitted once, from the chunk shared by all splits that
   need them or from the main module, keeping the alignment of every symbol in them, and the
-  per-module parts of a segment are only padded to the alignment they actually need.
+  per-module parts of a segment are only padded to the alignment they actually need. If a
+  relocated segment still does not fit its input, the data of the smallest modules is moved
+  into the main module instead of giving up on the whole segment.
 - Fix relocations inside a data symbol that is contained in another symbol being attributed to
   the containing symbol. A module that only used the inner symbol could miss the relocation's
   target. This was hidden by the whole-segment fallback above.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,11 @@
 ## wasm-split-cli vfuture
 
-- Fix data of split modules staying in the main module for optimized builds. `wasm-ld`
-  deduplicates and tail-merges strings, so several data symbols can share bytes. When such
-  symbols were needed by different output modules, the bytes were copied once per module,
-  the segment grew past its input and the whole segment was kept in the main module.
-  Bytes shared between modules are now emitted once, from the chunk shared by all splits that
-  need them or from the main module, keeping the alignment of every symbol in them, and the
-  data of all modules is placed by decreasing alignment, so that ordinary data needs no
-  padding. Each module emits one data segment per run of its data, typically one per alignment
-  it uses; the input's data segments keep their indices and the additional segments are
-  appended. If a relocated segment still does not fit its input, the data of the smallest
-  modules is moved into the main module instead of giving up on the whole segment, and this
-  is reported at info level.
+- Improve data layout in optimized builds, with less data ending up in the main module and more
+  data in the split modules, in particular when `wasm-ld` deduplicates strings and performs tail
+  merging (for details see #60).
 - Fix relocations inside a data symbol that is contained in another symbol being attributed to
   the containing symbol. A module that only used the inner symbol could miss the relocation's
-  target. This was hidden by the whole-segment fallback above.
+  target. This was hidden by whole segments being kept in the main module.
 
 ## wasm-split-cli v0.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## wasm-split-cli vfuture
 
+- Fix data of split modules staying in the main module for optimized builds. `wasm-ld`
+  deduplicates and tail-merges strings, so several data symbols can share bytes. When such
+  symbols were needed by different output modules, the bytes were copied once per module,
+  the segment grew past its input and the whole segment was kept in the main module.
+  Bytes shared between modules are now emitted once, from the main module, keeping the
+  alignment of every symbol in them, and the per-module parts of a segment are only padded
+  to the alignment they actually need.
+
 ## wasm-split-cli v0.2.3
 
 - Fix breakage from wasm-bindgen 0.128, which changes how casts are generated, leading to

--- a/crates/wasm_split_cli/src/dep_graph.rs
+++ b/crates/wasm_split_cli/src/dep_graph.rs
@@ -305,14 +305,16 @@ fn iter_data_dependencies<'m>(
                 }) {
                     let _ = overlap_candidates.pop();
                 }
-                let &target = emit_iter_err!(overlap_candidates.last().ok_or_else(|| anyhow!(
-                    "Invalid relocation entry {entry:?} not overlapping any data symbols"
+                // The relocation belongs to the smallest symbol that fully contains it. Inner
+                // symbols on the stack may only partially overlap it, in which case it belongs
+                // to the symbol containing them.
+                let target = overlap_candidates.iter().rev().find(|candidate| {
+                    candidate.range.start <= reloc_file_range.start
+                        && reloc_file_range.end <= candidate.range.end
+                });
+                let &target = emit_iter_err!(target.ok_or_else(|| anyhow!(
+                    "Invalid relocation entry {entry:?} not fully contained inside any data symbol"
                 )));
-                if !(target.range.start <= reloc_file_range.start
-                    && reloc_file_range.end <= target.range.end)
-                {
-                    emit_iter_err!(Err(anyhow!("Invalid relocation entry {entry:?} not fully contained inside its data symbol")))
-                }
                 return Some(Ok(DataDependency::Reloc(target, entry)));
             }
         }
@@ -351,6 +353,10 @@ fn iter_data_dependencies<'m>(
 
         // if we reach here, then the next symbol is contained in all items on the stack
         if let Some(container) = container {
+            // Keep the inner symbol as a candidate: relocations inside it must be attributed to
+            // it, the smallest symbol containing them, and not to its container. Otherwise a
+            // module that only needs the inner symbol would miss the relocation's target.
+            overlap_candidates.push(next_symbol);
             return Some(Ok(DataDependency::Containment {
                 container,
                 inner: next_symbol,

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -655,15 +655,6 @@ impl DataEmitInfo {
                     // happens to be the module currently chosen: its splits are needed too.
                     back.needed_by
                         .also_in(&program_info.output_modules[module_index].0);
-                    let placement = placement_module(&back.needed_by);
-                    if placement != back.in_module {
-                        trace!(
-                            "data symbol {symbol_index} shares bytes {data_range:?} of segment \
-                            {segment_index} with output module {}, emitting them from module {placement}",
-                            back.in_module
-                        );
-                        back.in_module = placement;
-                    }
                     range_lookup.insert(symbol_index, (range_idx, range_offset));
                 }
             }
@@ -676,6 +667,21 @@ impl DataEmitInfo {
                     segment_offset: u64::MAX, // filled in later
                 });
                 range_lookup.insert(symbol_index, (range_idx, 0));
+            }
+        }
+        // Derive placement from `needed_by` once all owners are known.
+        for segment in &mut per_segment {
+            if let DataSegmentAnalysis::Ranges { ranges, .. } = segment {
+                for range in ranges {
+                    let placement = placement_module(&range.needed_by);
+                    if placement != range.in_module {
+                        trace!(
+                            "data range {:?} placed in module {placement}",
+                            range.input_range
+                        );
+                    }
+                    range.in_module = placement;
+                }
             }
         }
         // finally transform them into output form

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -20,6 +20,8 @@ use wasmparser::{
     SymbolInfo, TypeRef,
 };
 
+const MAIN_MODULE: usize = 0;
+
 pub(crate) struct EmitState<'a> {
     input_options: &'a crate::Options<'a>,
     input_module: &'a InputModule<'a>,
@@ -479,7 +481,7 @@ impl DataEmitInfo {
                         wasmparser::Operator::I64Const { value } => u64::try_from(value).map_err(|_| value),
                         op => {
                             warn!("Non-constant operator {op:?} found to specify a memory's base address. Putting it into main.");
-                            return Ok(DataSegmentAnalysis::FromInputOnlyIn(0));
+                            return Ok(DataSegmentAnalysis::FromInputOnlyIn(MAIN_MODULE));
                         }
                     };
                     let address = match address {
@@ -488,7 +490,7 @@ impl DataEmitInfo {
                     };
                     if overlaps_other_segment(segment_idx) {
                         warn!("Data segment {segment_idx} overlaps another data segment in memory. Putting it into main.");
-                        return Ok(DataSegmentAnalysis::FromInputOnlyIn(0));
+                        return Ok(DataSegmentAnalysis::FromInputOnlyIn(MAIN_MODULE));
                     }
                     Ok(DataSegmentAnalysis::Ranges {
                         ranges: vec![],
@@ -511,7 +513,6 @@ impl DataEmitInfo {
         // emitted from a module that is loaded whenever any of them is: the chunk shared by
         // all the splits requiring it, or else the main module. The other modules refer to
         // its address.
-        const MAIN_MODULE: usize = 0;
         let module_by_identifier: HashMap<&SplitModuleIdentifier, usize> = program_info
             .output_modules
             .iter()
@@ -762,7 +763,7 @@ impl DataEmitInfo {
                         None => {
                             trace!("{ranges:?}");
                             warn!("Overlong segment {segment_index} after relocation, putting it in main module.");
-                            DataSegmentEmitInfo::FromInputOnlyIn(0)
+                            DataSegmentEmitInfo::FromInputOnlyIn(MAIN_MODULE)
                         }
                     }
                 }
@@ -960,7 +961,7 @@ impl<'a> ModuleEmitState<'a> {
                 continue;
             }
             debug_assert!(
-                output_module_index == 0,
+                output_module_index == MAIN_MODULE,
                 "expected a function import to happen in the main module"
             );
             let import = &emit_state.input_module.imports[func_import.import_id];
@@ -1136,7 +1137,7 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn is_main(&self) -> bool {
-        self.output_module_index == 0
+        self.output_module_index == MAIN_MODULE
     }
 
     fn get_relocated_data(&self, range: Range<InputOffset>) -> Result<Vec<u8>> {

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -437,16 +437,23 @@ impl DataEmitInfo {
         // Active segments are initialized in index order. Relocated data is emitted in
         // additional segments after all input segments, which is only order-preserving when the
         // input segments do not overlap in memory. wasm-ld never lets them overlap, but a
-        // hand-made input may; keep such segments as they are, in their slots.
+        // hand-made input may; keep overlapping segments as they are, in their slots. An active
+        // segment with an unknown address may overlap any other active segment; passive
+        // segments have no address at instantiation and do not affect this ordering.
+        let mut active_unknown_address = None;
         let segment_extents: Vec<Option<Range<u64>>> = input_module
             .data_segments
             .iter()
-            .map(|segment| match &segment.kind {
+            .enumerate()
+            .map(|(segment_idx, segment)| match &segment.kind {
                 DataKind::Active { offset_expr, .. } => {
-                    match offset_expr.get_operators_reader().read().ok()? {
-                        wasmparser::Operator::I32Const { value } => Some(value as u32 as u64),
-                        wasmparser::Operator::I64Const { value } => Some(value as u64),
-                        _ => None,
+                    match offset_expr.get_operators_reader().read() {
+                        Ok(wasmparser::Operator::I32Const { value }) => Some(value as u32 as u64),
+                        Ok(wasmparser::Operator::I64Const { value }) => Some(value as u64),
+                        _ => {
+                            active_unknown_address.get_or_insert(segment_idx);
+                            None
+                        }
                     }
                     .map(|base| base..base + wasm_data_len(segment))
                 }
@@ -454,6 +461,9 @@ impl DataEmitInfo {
             })
             .collect();
         let overlaps_other_segment = |segment_idx: usize| -> bool {
+            if active_unknown_address.is_some() {
+                return true;
+            }
             let Some(extent) = &segment_extents[segment_idx] else {
                 return false;
             };
@@ -495,7 +505,11 @@ impl DataEmitInfo {
                         Err(value) => { bail!("Invalid base address found: {value}"); },
                     };
                     if overlaps_other_segment(segment_idx) {
-                        warn!("Data segment {segment_idx} overlaps another data segment in memory. Putting it into main.");
+                        if let Some(other) = active_unknown_address {
+                            warn!("Data segment {segment_idx} may overlap data segment {other} whose base address is not a constant. Putting it into main.");
+                        } else {
+                            warn!("Data segment {segment_idx} overlaps another data segment in memory. Putting it into main.");
+                        }
                         return Ok(DataSegmentAnalysis::FromInputOnlyIn(MAIN_MODULE));
                     }
                     Ok(DataSegmentAnalysis::Ranges {

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -13,7 +13,7 @@ use crate::{
     util::{wasm_data_len, wasm_data_start},
 };
 use eyre::{bail, Context, Result};
-use tracing::{trace, warn};
+use tracing::{info, trace, warn};
 use wasm_encoder::{reencode::Reencode, ConstExpr, EntityType, ProducersField, ProducersSection};
 use wasmparser::{
     Data, DataKind, DefinedDataSymbol, ExternalKind, Operator, RelocationType, SegmentFlags,
@@ -291,7 +291,8 @@ struct LateDataRange {
     // at an offset congruent to its input start modulo this alignment, so that every symbol in
     // it keeps its alignment.
     data_align: u64,
-    in_module_offset: u64,
+    // offset in the relocated segment, filled in by `layout_ranges`
+    segment_offset: u64,
 }
 
 impl LateDataRange {
@@ -306,61 +307,63 @@ impl LateDataRange {
     }
 }
 
+/// A contiguous run of ranges of one output module, emitted as one data segment.
+#[derive(Debug)]
+struct Fragment {
+    module: usize,
+    // offset in the relocated segment
+    offset: u64,
+    // the ranges, as a range of indices into `RangeLayout::emit_order`
+    ranges: Range<usize>,
+}
+
+#[derive(Debug)]
 struct RangeLayout {
-    // indices into the ranges, in the order they are emitted
-    range_emit_order: Vec<usize>,
-    // output module -> offset of its part in the segment
-    per_output_offset: HashMap<usize, u64>,
+    // indices into the ranges, in the order they are placed in the segment
+    emit_order: Vec<usize>,
+    // in placement order; the fragments of one module are in ascending order
+    fragments: Vec<Fragment>,
     segment_len: u64,
 }
 
-/// Lay out the ranges of one segment: each output module gets a contiguous part of the segment,
-/// and `in_module_offset` of every range is set relative to the part of its module.
+/// Lay out the ranges of one segment.
+///
+/// Ranges are placed by decreasing alignment, so that ordinary ranges (whose length is a
+/// multiple of their alignment) pack without padding no matter which module they belong to.
+/// Every module then emits one data segment per run of its ranges, typically one per alignment
+/// its data uses. Only merged ranges, which must keep their input residue and can have any
+/// length, can still cause padding.
 fn layout_ranges(ranges: &mut [LateDataRange]) -> RangeLayout {
-    let mut range_emit_order: Vec<_> = (0..ranges.len()).collect();
-    range_emit_order.sort_by_key(|&range_idx| {
+    let mut emit_order: Vec<_> = (0..ranges.len()).collect();
+    emit_order.sort_by_key(|&range_idx| {
         let range = &ranges[range_idx];
         (
-            range.in_module,
             std::cmp::Reverse(range.data_align),
+            range.in_module,
             range.input_range.start,
         )
     });
-    // reorder symbols per module
-    let mut per_module_size = HashMap::new();
-    // The first range of a module has the largest alignment (see the sort order above),
-    // which is all the module's part of the segment needs to be aligned to.
-    let mut per_module_align = HashMap::new();
-    for &range_idx in &range_emit_order {
+    let mut fragments: Vec<Fragment> = vec![];
+    let mut segment_len: u64 = 0;
+    for (order_idx, &range_idx) in emit_order.iter().enumerate() {
         let range = &mut ranges[range_idx];
-        let module_len = per_module_size.entry(range.in_module).or_insert(0);
-        per_module_align
-            .entry(range.in_module)
-            .or_insert(range.data_align);
-        let data_range = range.input_range.clone();
-        let data_offset = range.align_offset(*module_len);
-
-        // allocate it in that module
-        range.in_module_offset = data_offset;
-        *module_len = data_offset + (data_range.end - data_range.start);
-    }
-
-    // figure out module offsets. Parts with a larger alignment come first, so that padding is
-    // only needed after a part that mixes alignments.
-    let mut per_module_size = per_module_size.into_iter().collect::<Vec<_>>();
-    per_module_size
-        .sort_by_key(|&(module, _)| (std::cmp::Reverse(per_module_align[&module]), module));
-    let mut per_output_offset = HashMap::new();
-    let mut data_offset: u64 = 0;
-    for &(module, module_size) in &per_module_size {
-        data_offset = data_offset.next_multiple_of(per_module_align[&module]);
-        per_output_offset.insert(module, data_offset);
-        data_offset += module_size;
+        range.segment_offset = range.align_offset(segment_len);
+        segment_len = range.segment_offset + (range.input_range.end - range.input_range.start);
+        match fragments.last_mut() {
+            Some(fragment) if fragment.module == range.in_module => {
+                fragment.ranges.end = order_idx + 1;
+            }
+            _ => fragments.push(Fragment {
+                module: range.in_module,
+                offset: range.segment_offset,
+                ranges: order_idx..order_idx + 1,
+            }),
+        }
     }
     RangeLayout {
-        range_emit_order,
-        per_output_offset,
-        segment_len: data_offset,
+        emit_order,
+        fragments,
+        segment_len,
     }
 }
 
@@ -372,20 +375,43 @@ enum DataSegmentEmitInfo {
     Ranges {
         // some reloc information
         base_address: u64,
-        per_output_offset: HashMap<usize, u64>,
-        // the output segment is formed by concatenating all these segment
+        // the output segments are formed by concatenating runs of these ranges
         ranges: Vec<LateDataRange>,
         // symbol index -> (index in 'ranges', offset in range)
         range_lookup: HashMap<usize, (usize, u64)>,
-        // we re-order ranges to put data with larger alignment up front (this saves padding bytes).
-        // since indices are stored in the range_lookup map, we can't do this in-place and maintain a separate order here.
-        range_emit_order: Vec<usize>,
+        layout: RangeLayout,
     },
 }
 
 #[derive(Debug)]
 struct DataEmitInfo {
     per_segment: Vec<DataSegmentEmitInfo>,
+}
+
+impl DataEmitInfo {
+    /// The fragments of `segment_idx` that `module` emits, in ascending order.
+    fn fragments(&self, segment_idx: usize, module: usize) -> impl Iterator<Item = &Fragment> {
+        let fragments = match &self.per_segment[segment_idx] {
+            DataSegmentEmitInfo::Ranges { layout, .. } => layout.fragments.as_slice(),
+            _ => &[],
+        };
+        fragments
+            .iter()
+            .filter(move |fragment| fragment.module == module)
+    }
+
+    /// Every input segment keeps its index in every output module, holding the module's first
+    /// fragment of it (or nothing). Further fragments are appended after all input segments;
+    /// this lists them as `(input segment, fragment)`, in the order they are appended.
+    fn extra_fragments(&self, module: usize) -> Vec<(usize, &Fragment)> {
+        (0..self.per_segment.len())
+            .flat_map(|segment_idx| {
+                self.fragments(segment_idx, module)
+                    .skip(1)
+                    .map(move |fragment| (segment_idx, fragment))
+            })
+            .collect()
+    }
 }
 
 impl DataEmitInfo {
@@ -400,6 +426,39 @@ impl DataEmitInfo {
                 base_address: u64,
             },
         }
+        // Active segments are initialized in index order. Relocated data is emitted in
+        // additional segments after all input segments, which is only order-preserving when the
+        // input segments do not overlap in memory. wasm-ld never lets them overlap, but a
+        // hand-made input may; keep such segments as they are, in their slots.
+        let segment_extents: Vec<Option<Range<u64>>> = input_module
+            .data_segments
+            .iter()
+            .map(|segment| match &segment.kind {
+                DataKind::Active { offset_expr, .. } => {
+                    match offset_expr.get_operators_reader().read().ok()? {
+                        wasmparser::Operator::I32Const { value } => Some(value as u32 as u64),
+                        wasmparser::Operator::I64Const { value } => Some(value as u64),
+                        _ => None,
+                    }
+                    .map(|base| base..base + wasm_data_len(segment))
+                }
+                DataKind::Passive => None,
+            })
+            .collect();
+        let overlaps_other_segment = |segment_idx: usize| -> bool {
+            let Some(extent) = &segment_extents[segment_idx] else {
+                return false;
+            };
+            segment_extents
+                .iter()
+                .enumerate()
+                .any(|(other_idx, other)| {
+                    other_idx != segment_idx
+                        && other.as_ref().is_some_and(|other| {
+                            extent.start < other.end && other.start < extent.end
+                        })
+                })
+        };
         let mut per_segment = input_module
             .data_segments
             .iter()
@@ -427,6 +486,10 @@ impl DataEmitInfo {
                         Ok(addr) => addr,
                         Err(value) => { bail!("Invalid base address found: {value}"); },
                     };
+                    if overlaps_other_segment(segment_idx) {
+                        warn!("Data segment {segment_idx} overlaps another data segment in memory. Putting it into main.");
+                        return Ok(DataSegmentAnalysis::FromInputOnlyIn(0));
+                    }
                     Ok(DataSegmentAnalysis::Ranges {
                         ranges: vec![],
                         range_lookup: HashMap::new(),
@@ -610,7 +673,7 @@ impl DataEmitInfo {
                     needed_by: program_info.output_modules[module_index].0.clone(),
                     in_module: module_index,
                     data_align,
-                    in_module_offset: u64::MAX, // filled in later
+                    segment_offset: u64::MAX, // filled in later
                 });
                 range_lookup.insert(symbol_index, (range_idx, 0));
             }
@@ -634,12 +697,24 @@ impl DataEmitInfo {
                     // would not be a problem. Since we can't guarantee this at this point though, don't risk it.
                     // Overlapping segments *will* overwrite data!
                     // Instead, as long as the relocated segment is longer than its input, fold the data of the
-                    // smallest module into the main module. That removes the padding between their parts.
-                    // Merged ranges can still need more padding than the input had, so even with all data
-                    // in the main module the segment may not fit; then the whole segment is copied instead.
+                    // smallest module into the main module and try again. That changes the order of the
+                    // ranges and usually reduces the padding that merged ranges need. It is not guaranteed
+                    // to: even with all data in the main module the segment may not fit, and then the whole
+                    // segment is copied instead.
+                    let mut folded_modules = 0usize;
+                    let mut folded_bytes = 0u64;
+                    let mut first_len = None;
                     let layout = loop {
                         let layout = layout_ranges(&mut ranges);
+                        let first_len = *first_len.get_or_insert(layout.segment_len);
                         if layout.segment_len <= input_len {
+                            if folded_modules != 0 {
+                                info!(
+                                    "Relocated data segment {segment_index} was longer than its input \
+                                    ({first_len} > {input_len} bytes): moved {folded_bytes} bytes of \
+                                    {folded_modules} module(s) into the main module to make it fit"
+                                );
+                            }
                             break Some(layout);
                         }
                         let mut per_module_size = HashMap::new();
@@ -658,6 +733,8 @@ impl DataEmitInfo {
                             moving the {size} data bytes of output module {module} into the main module",
                             layout.segment_len - input_len
                         );
+                        folded_modules += 1;
+                        folded_bytes += size;
                         for range in ranges.iter_mut().filter(|range| range.in_module == module) {
                             range.in_module = MAIN_MODULE;
                         }
@@ -670,16 +747,11 @@ impl DataEmitInfo {
                     // So for the moment, don't bother with this sanity analysis.
 
                     match layout {
-                        Some(RangeLayout {
-                            range_emit_order,
-                            per_output_offset,
-                            ..
-                        }) => DataSegmentEmitInfo::Ranges {
+                        Some(layout) => DataSegmentEmitInfo::Ranges {
                             ranges,
                             base_address,
-                            per_output_offset,
                             range_lookup,
-                            range_emit_order,
+                            layout,
                         },
                         None => {
                             trace!("{ranges:?}");
@@ -705,7 +777,6 @@ impl DataEmitInfo {
         let DataSegmentEmitInfo::Ranges {
             ranges,
             base_address,
-            per_output_offset,
             range_lookup,
             ..
         } = &self.per_segment[segment_idx]
@@ -717,11 +788,7 @@ impl DataEmitInfo {
             return Err(());
         };
         let range = &ranges[range_index];
-        let mut address = *base_address;
-        address += per_output_offset[&range.in_module];
-        address += range.in_module_offset;
-        address += offset_in_range;
-        Ok(Some(address))
+        Ok(Some(base_address + range.segment_offset + offset_in_range))
     }
 }
 
@@ -1334,7 +1401,12 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_data_count_section(&mut self) {
-        let data_section_count = self.input_module.data_segments.len();
+        let data_section_count = self.input_module.data_segments.len()
+            + self
+                .emit_state
+                .data_relocations
+                .extra_fragments(self.output_module_index)
+                .len();
         let section = wasm_encoder::DataCountSection {
             count: data_section_count
                 .try_into()
@@ -1476,56 +1548,75 @@ impl<'a> ModuleEmitState<'a> {
         self.get_relocated_data(range_start..range_end)
     }
 
+    /// The data of `fragment`, with the relocations inside applied.
+    fn fragment_data(&self, segment_idx: usize, fragment: &Fragment) -> Result<Vec<u8>> {
+        let DataSegmentEmitInfo::Ranges { ranges, layout, .. } =
+            &self.emit_state.data_relocations.per_segment[segment_idx]
+        else {
+            unreachable!("fragments only exist for relocated segments");
+        };
+        let input_range_start = wasm_data_start(&self.input_module.data_segments[segment_idx]);
+        let mut data = vec![];
+        for &range_idx in &layout.emit_order[fragment.ranges.clone()] {
+            let range = &ranges[range_idx];
+            let input_range = (input_range_start + range.input_range.start)
+                ..(input_range_start + range.input_range.end);
+            data.resize((range.segment_offset - fragment.offset) as usize, 0); // pad with zeroes
+            data.extend(self.get_relocated_data(input_range)?);
+        }
+        Ok(data)
+    }
+
     fn generate_data_section(&mut self) -> Result<()> {
         let data_reloc = &self.emit_state.data_relocations;
         let mut section = wasm_encoder::DataSection::new();
+        // `(input segment, address, data)`; the address is `None` to copy the input's offset
+        let mut segments: Vec<(usize, Option<u64>, Vec<u8>)> = vec![];
+        // Every input segment keeps its index, so that indices in the code stay valid.
         for (segment_idx, segment) in data_reloc.per_segment.iter().enumerate() {
             let input_data = &self.input_module.data_segments[segment_idx];
-            let input_range_start = wasm_data_start(input_data);
-
-            let mut data: Vec<u8>;
-            let addr_offset: Option<u64>;
-            match segment {
+            let (addr_offset, data) = match segment {
                 DataSegmentEmitInfo::FromInputInAll => {
-                    addr_offset = None;
-                    data = self.get_relocated_segment_data(input_data)?;
+                    (None, self.get_relocated_segment_data(input_data)?)
                 }
                 DataSegmentEmitInfo::FromInputOnlyIn(module)
                     if *module == self.output_module_index =>
                 {
-                    addr_offset = None;
-                    data = self.get_relocated_segment_data(input_data)?;
+                    (None, self.get_relocated_segment_data(input_data)?)
                 }
                 DataSegmentEmitInfo::FromInputOnlyIn(_) => {
-                    addr_offset = None;
-                    data = vec![]; // no data, but emit the module to not shift data indices
+                    (None, vec![]) // no data, but emit the segment to not shift data indices
                 }
-                DataSegmentEmitInfo::Ranges {
-                    ranges,
-                    range_emit_order,
-                    per_output_offset,
-                    base_address,
-                    ..
-                } => {
-                    if let Some(module_offset) = per_output_offset.get(&self.output_module_index) {
-                        addr_offset = Some(base_address + *module_offset);
-                    } else {
-                        addr_offset = None;
-                    }
-                    data = vec![];
-                    for &range_idx in range_emit_order {
-                        let range = &ranges[range_idx];
-                        if range.in_module != self.output_module_index {
-                            continue;
-                        }
-                        let data_range = &range.input_range;
-                        let input_range = (input_range_start + data_range.start)
-                            ..(input_range_start + data_range.end);
-                        data.resize(range.in_module_offset as usize, 0); // pad with zeroes
-                        data.extend(self.get_relocated_data(input_range)?);
+                DataSegmentEmitInfo::Ranges { base_address, .. } => {
+                    match data_reloc
+                        .fragments(segment_idx, self.output_module_index)
+                        .next()
+                    {
+                        Some(fragment) => (
+                            Some(base_address + fragment.offset),
+                            self.fragment_data(segment_idx, fragment)?,
+                        ),
+                        None => (None, vec![]),
                     }
                 }
-            }
+            };
+            segments.push((segment_idx, addr_offset, data));
+        }
+        // Further fragments are appended, see `DataEmitInfo::extra_fragments`.
+        for (segment_idx, fragment) in data_reloc.extra_fragments(self.output_module_index) {
+            let DataSegmentEmitInfo::Ranges { base_address, .. } =
+                &data_reloc.per_segment[segment_idx]
+            else {
+                unreachable!("fragments only exist for relocated segments");
+            };
+            segments.push((
+                segment_idx,
+                Some(base_address + fragment.offset),
+                self.fragment_data(segment_idx, fragment)?,
+            ));
+        }
+        for (segment_idx, addr_offset, data) in segments {
+            let input_data = &self.input_module.data_segments[segment_idx];
             match input_data.kind {
                 DataKind::Passive => {
                     section.passive(data);
@@ -1626,9 +1717,23 @@ impl<'a> ModuleEmitState<'a> {
         section.memories(&convert_name_hash_map(&self.input_module.names.memories));
         section.globals(&convert_name_hash_map(&self.input_module.names.globals));
         // elements
-        section.data(&convert_name_hash_map(
-            &self.input_module.names.data_segments,
-        ));
+        {
+            // appended fragments are named after their input segment
+            let mut data_names = self.input_module.names.data_segments.clone();
+            let input_count = self.input_module.data_segments.len();
+            for (i, (segment_idx, _)) in self
+                .emit_state
+                .data_relocations
+                .extra_fragments(self.output_module_index)
+                .into_iter()
+                .enumerate()
+            {
+                if let Some(name) = self.input_module.names.data_segments.get(&segment_idx) {
+                    data_names.insert(input_count + i, name);
+                }
+            }
+            section.data(&convert_name_hash_map(&data_names));
+        }
         // tag
         // fields
         // tags

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -283,6 +283,9 @@ impl IndirectFunctionEmitInfo {
 #[derive(Debug)]
 struct LateDataRange {
     input_range: Range<u64>,
+    // the modules whose symbols are in this range, see `SplitModuleIdentifier::also_in`
+    needed_by: SplitModuleIdentifier,
+    // the module emitting this range, which is loaded whenever any of `needed_by` is
     in_module: usize,
     // power of 2, the strictest alignment of the symbols in the range. The range must be placed
     // at an offset congruent to its input start modulo this alignment, so that every symbol in
@@ -384,9 +387,39 @@ impl DataEmitInfo {
         // than its input and forces the *whole* segment into the main module (see below).
         // Instead, the symbols of all modules are sorted by input position and overlapping
         // symbols are merged into one range. A range needed by more than one output module is
-        // emitted from the main module, which is always loaded first. The other modules refer
-        // to its address.
+        // emitted from a module that is loaded whenever any of them is: the chunk shared by
+        // all the splits requiring it, or else the main module. The other modules refer to
+        // its address.
         const MAIN_MODULE: usize = 0;
+        let module_by_identifier: HashMap<&SplitModuleIdentifier, usize> = program_info
+            .output_modules
+            .iter()
+            .enumerate()
+            .map(|(index, (identifier, _))| (identifier, index))
+            .collect();
+        // The output module to emit a range from that is required by `needed_by`.
+        let placement_module = |needed_by: &SplitModuleIdentifier| -> usize {
+            if let Some(&index) = module_by_identifier.get(needed_by) {
+                return index;
+            }
+            let SplitModuleIdentifier::Chunk(needed_by) = needed_by else {
+                return MAIN_MODULE;
+            };
+            // No chunk is shared by exactly these splits: use the smallest one that is loaded
+            // by all of them, if any.
+            program_info
+                .output_modules
+                .iter()
+                .enumerate()
+                .filter_map(|(index, (identifier, _))| match identifier {
+                    SplitModuleIdentifier::Chunk(splits) if splits.is_superset(needed_by) => {
+                        Some((splits.len(), index))
+                    }
+                    _ => None,
+                })
+                .min()
+                .map_or(MAIN_MODULE, |(_, index)| index)
+        };
         let mut included_symbols = Vec::new();
         for (module_index, (_, module)) in program_info.output_modules.iter().enumerate() {
             for symbol in module.included_symbols.iter() {
@@ -495,13 +528,20 @@ impl DataEmitInfo {
                     // The range is placed congruent to its input start modulo its alignment, so
                     // taking the strictest alignment keeps every symbol in it aligned.
                     back.data_align = back.data_align.max(data_align);
-                    if back.in_module != module_index && back.in_module != MAIN_MODULE {
+                    // Track the modules actually needing the range, not the module chosen to
+                    // emit it: the latter may be a superset chunk, which would rule out an exact
+                    // chunk for a later, larger requirement. Record every owner, even one that
+                    // happens to be the module currently chosen: its splits are needed too.
+                    back.needed_by
+                        .also_in(&program_info.output_modules[module_index].0);
+                    let placement = placement_module(&back.needed_by);
+                    if placement != back.in_module {
                         trace!(
                             "data symbol {symbol_index} shares bytes {data_range:?} of segment \
-                            {segment_index} with output module {}, emitting them from the main module",
+                            {segment_index} with output module {}, emitting them from module {placement}",
                             back.in_module
                         );
-                        back.in_module = MAIN_MODULE;
+                        back.in_module = placement;
                     }
                     range_lookup.insert(symbol_index, (range_idx, range_offset));
                 }
@@ -509,6 +549,7 @@ impl DataEmitInfo {
             if !has_merged {
                 ranges.push(LateDataRange {
                     input_range: data_range,
+                    needed_by: program_info.output_modules[module_index].0.clone(),
                     in_module: module_index,
                     data_align,
                     in_module_offset: u64::MAX, // filled in later

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -289,9 +289,9 @@ struct LateDataRange {
     needed_by: SplitModuleIdentifier,
     // the module emitting this range, which is loaded whenever any of `needed_by` is
     in_module: usize,
-    // power of 2, the strictest alignment of the symbols in the range. The range must be placed
-    // at an offset congruent to its input start modulo this alignment, so that every symbol in
-    // it keeps its alignment.
+    /// Power of 2, the strictest alignment of the symbols in the range, which may be stricter
+    /// than the alignment of its start. `align_offset` preserves the input start's residue
+    /// modulo this alignment so that every contained symbol keeps its alignment.
     data_align: u64,
     // offset in the relocated segment, filled in by `layout_ranges`
     segment_offset: u64,
@@ -299,6 +299,12 @@ struct LateDataRange {
 
 impl LateDataRange {
     /// The smallest offset `>= from` at which this range keeps the alignment of its symbols.
+    ///
+    /// This is not `from.next_multiple_of(self.data_align)`: a 4-aligned symbol at input
+    /// offset 4 merged with an 8-aligned symbol at offset 8 gives a range starting at 4
+    /// with alignment 8. Placing the range congruent to its input start modulo 8 keeps
+    /// the inner symbol aligned; rounding the range's start up to a multiple of 8 would
+    /// put that symbol at offset 4 modulo 8 and misalign it.
     fn align_offset(&self, from: u64) -> u64 {
         let residue = self.input_range.start % self.data_align;
         let mut offset = from / self.data_align * self.data_align + residue;
@@ -1888,4 +1894,36 @@ pub fn emit_modules<'info, M>(
         })
         .filter_map(|res| res.transpose())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn align_offset_preserves_input_residue() {
+        let mut range = LateDataRange {
+            input_range: 0..16,
+            needed_by: SplitModuleIdentifier::Main,
+            in_module: MAIN_MODULE,
+            data_align: 8,
+            segment_offset: 0,
+        };
+        for from in [0, 1, 4, 5, 8, 12, 13, 16] {
+            assert_eq!(range.align_offset(from), from.next_multiple_of(8));
+        }
+
+        // The inner 8-aligned symbol starts four bytes into the merged range.
+        range.input_range = 4..16;
+        for (from, expected) in [(0, 4), (1, 4), (4, 4), (5, 12), (12, 12), (13, 20)] {
+            let offset = range.align_offset(from);
+            assert_eq!(offset, expected, "from {from}");
+            assert_eq!((offset + 4) % 8, 0, "inner symbol alignment");
+        }
+
+        range.data_align = 1;
+        for from in [0, 1, 4, 5, 12, 13] {
+            assert_eq!(range.align_offset(from), from);
+        }
+    }
 }

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -13,7 +13,7 @@ use crate::{
     util::{wasm_data_len, wasm_data_start},
 };
 use eyre::{bail, Context, Result};
-use tracing::{info, trace, warn};
+use tracing::{trace, warn};
 use wasm_encoder::{reencode::Reencode, ConstExpr, EntityType, ProducersField, ProducersSection};
 use wasmparser::{
     Data, DataKind, DefinedDataSymbol, ExternalKind, Operator, RelocationType, SegmentFlags,
@@ -709,7 +709,7 @@ impl DataEmitInfo {
                         let first_len = *first_len.get_or_insert(layout.segment_len);
                         if layout.segment_len <= input_len {
                             if folded_modules != 0 {
-                                info!(
+                                warn!(
                                     "Relocated data segment {segment_index} was longer than its input \
                                     ({first_len} > {input_len} bytes): moved {folded_bytes} bytes of \
                                     {folded_modules} module(s) into the main module to make it fit"

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -284,8 +284,23 @@ impl IndirectFunctionEmitInfo {
 struct LateDataRange {
     input_range: Range<u64>,
     in_module: usize,
-    data_align: u64, // power of 2
+    // power of 2, the strictest alignment of the symbols in the range. The range must be placed
+    // at an offset congruent to its input start modulo this alignment, so that every symbol in
+    // it keeps its alignment.
+    data_align: u64,
     in_module_offset: u64,
+}
+
+impl LateDataRange {
+    /// The smallest offset `>= from` at which this range keeps the alignment of its symbols.
+    fn align_offset(&self, from: u64) -> u64 {
+        let residue = self.input_range.start % self.data_align;
+        let mut offset = from / self.data_align * self.data_align + residue;
+        if offset < from {
+            offset += self.data_align;
+        }
+        offset
+    }
 }
 
 #[derive(Debug)]
@@ -360,122 +375,145 @@ impl DataEmitInfo {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        // Now go through all data symbols
+        // Now go through the data symbols of all output modules.
+        //
+        // wasm-ld can place several symbols onto the same bytes: identical constants are
+        // deduplicated and strings are tail-merged when optimizing. These symbols do not
+        // necessarily end up in the same output module. Relocating the symbols of each module
+        // on its own would copy the shared bytes once per module, which makes the segment longer
+        // than its input and forces the *whole* segment into the main module (see below).
+        // Instead, the symbols of all modules are sorted by input position and overlapping
+        // symbols are merged into one range. A range needed by more than one output module is
+        // emitted from the main module, which is always loaded first. The other modules refer
+        // to its address.
+        const MAIN_MODULE: usize = 0;
+        let mut included_symbols = Vec::new();
         for (module_index, (_, module)) in program_info.output_modules.iter().enumerate() {
-            let mut included_symbols = module
-                .included_symbols
-                .iter()
-                .filter_map(|symbol| {
-                    let DepNode::DataSymbol(symbol_index) = *symbol else {
-                        return None;
-                    };
-                    let SymbolInfo::Data {
-                        symbol: Some(def_data),
-                        ..
-                    } = input_module.reloc_info.symbols[symbol_index]
-                    else {
-                        // Undefined data symbol: nothing defines it, so there is
-                        // no definition to place and no address to relocate.
-                        // The linker already resolved every reference to it
-                        // (to 0 under --allow-undefined), and `reloc_value`
-                        // leaves such references untouched, so the symbol
-                        // simply has no place in the emit state. Toolchains
-                        // produce these in the wild, e.g. rustc incremental
-                        // builds whose reused objects still reference renamed
-                        // promoted anonymous globals (rust-lang/rust#81280).
-                        if let SymbolInfo::Data { name, .. } =
-                            input_module.reloc_info.symbols[symbol_index]
-                        {
-                            trace!("undefined data symbol {name:?} in included set; references keep their linker value");
-                        }
-                        return None;
-                    };
-                    if def_data.size == 0 {
-                        // We don't care about zero-sized symbols.
-                        // There are some prominent examples, specifically __heap_base, that lead to a zero-sized
-                        // data symbol in the output. For this example specifically, it sometimes leads to problems
-                        // since it is often outside the range of data defined via segments in the input.
-                        return None;
-                    }
-                    let segment_index = def_data.index as usize;
-                    let DataSegmentAnalysis::Ranges { .. } = &per_segment[segment_index] else {
-                        // Only relocate if in active range
-                        return None;
-                    };
-                    Some(Ok((symbol_index, def_data)))
-                })
-                .collect::<Result<Vec<_>>>()?;
-            // all keys are unique by the inclusion of the symbol index
-            included_symbols.sort_unstable_by_key(|&(sym_index, ref def_data)| {
-                (def_data.index, def_data.offset, sym_index)
-            });
-            for (symbol_index, def_data) in included_symbols {
-                let segment_index = def_data.index as usize;
-                let DataSegmentAnalysis::Ranges {
-                    ranges,
-                    range_lookup,
-                    ..
-                } = &mut per_segment[segment_index]
-                else {
-                    // filtered above. All passive ranges are put into the main module
-                    unreachable!(
-                        "data symbol in passive range should not have gotted included in this pass"
-                    );
+            for symbol in module.included_symbols.iter() {
+                let DepNode::DataSymbol(symbol_index) = *symbol else {
+                    continue;
                 };
-                let data_len = u64::from(def_data.size);
-                let data_offset = u64::from(def_data.offset);
-                let data_range = data_offset..data_offset + data_len;
-
-                let in_segment = &input_module.data_segments[segment_index];
-                if data_range.end > wasm_data_len(in_segment) {
-                    unreachable!(
-                        "Found data symbol {:?} that extends past the input module's data \
-                        bytes: {data_range:?} not in range for data segment of length {}",
-                        input_module.reloc_info.symbols[symbol_index],
-                        in_segment.data.len()
-                    );
-                }
-
-                let segment_align =
-                    1u64 << input_module.reloc_info.segments[segment_index].alignment;
-
-                let mut data_align = segment_align;
-                if data_offset != 0 {
-                    // TODO: .isolate_least_significant_one()
-                    data_align = data_align.min(1 << data_offset.trailing_zeros());
-                }
-                debug_assert!(data_len != 0, "zero-sized symbols handled previously");
-                data_align = data_align.min(1 << data_len.trailing_zeros());
-
-                let mut has_merged = false;
-                let range_idx = ranges.len();
-                if let Some(back) = ranges.last_mut() {
-                    let has_overlap =
-                        back.in_module == module_index && data_offset < back.input_range.end;
-                    if has_overlap {
-                        // we sorted before ingesting, hence the existing range starts earlier
-                        debug_assert!(
-                            back.input_range.start <= data_offset,
-                            "overlapping range goes backwards"
-                        );
-                        let range_offset = data_offset - back.input_range.start;
-                        let range_idx = range_idx - 1; // back of ranges
-
-                        has_merged = true;
-                        // about alignment: we use the fact that llvm merged these symbols as proof that we too, do not have to worry about alignment
-                        back.input_range.end = back.input_range.end.max(data_range.end);
-                        range_lookup.insert(symbol_index, (range_idx, range_offset));
+                let SymbolInfo::Data {
+                    symbol: Some(def_data),
+                    ..
+                } = input_module.reloc_info.symbols[symbol_index]
+                else {
+                    // Undefined data symbol: nothing defines it, so there is
+                    // no definition to place and no address to relocate.
+                    // The linker already resolved every reference to it
+                    // (to 0 under --allow-undefined), and `reloc_value`
+                    // leaves such references untouched, so the symbol
+                    // simply has no place in the emit state. Toolchains
+                    // produce these in the wild, e.g. rustc incremental
+                    // builds whose reused objects still reference renamed
+                    // promoted anonymous globals (rust-lang/rust#81280).
+                    if let SymbolInfo::Data { name, .. } =
+                        input_module.reloc_info.symbols[symbol_index]
+                    {
+                        trace!("undefined data symbol {name:?} in included set; references keep their linker value");
                     }
+                    continue;
+                };
+                if def_data.size == 0 {
+                    // We don't care about zero-sized symbols.
+                    // There are some prominent examples, specifically __heap_base, that lead to a zero-sized
+                    // data symbol in the output. For this example specifically, it sometimes leads to problems
+                    // since it is often outside the range of data defined via segments in the input.
+                    continue;
                 }
-                if !has_merged {
-                    ranges.push(LateDataRange {
-                        input_range: data_range,
-                        in_module: module_index,
-                        data_align,
-                        in_module_offset: u64::MAX, // filled in later
-                    });
-                    range_lookup.insert(symbol_index, (range_idx, 0));
+                let segment_index = def_data.index as usize;
+                let DataSegmentAnalysis::Ranges { .. } = &per_segment[segment_index] else {
+                    // Only relocate if in active range
+                    continue;
+                };
+                included_symbols.push((module_index, symbol_index, def_data));
+            }
+        }
+        // Symbols starting at the same offset are ordered longest first, so that a range always
+        // begins with the symbol that extends furthest. All keys are unique by the inclusion of
+        // the symbol index.
+        included_symbols.sort_unstable_by_key(|&(_, sym_index, ref def_data)| {
+            (
+                def_data.index,
+                def_data.offset,
+                std::cmp::Reverse(def_data.size),
+                sym_index,
+            )
+        });
+        for (module_index, symbol_index, def_data) in included_symbols {
+            let segment_index = def_data.index as usize;
+            let DataSegmentAnalysis::Ranges {
+                ranges,
+                range_lookup,
+                ..
+            } = &mut per_segment[segment_index]
+            else {
+                // filtered above. Passive and TLS segments are copied to every module.
+                unreachable!(
+                    "data symbol in passive range should not have gotted included in this pass"
+                );
+            };
+            let data_len = u64::from(def_data.size);
+            let data_offset = u64::from(def_data.offset);
+            let data_range = data_offset..data_offset + data_len;
+
+            let in_segment = &input_module.data_segments[segment_index];
+            if data_range.end > wasm_data_len(in_segment) {
+                unreachable!(
+                    "Found data symbol {:?} that extends past the input module's data \
+                    bytes: {data_range:?} not in range for data segment of length {}",
+                    input_module.reloc_info.symbols[symbol_index],
+                    in_segment.data.len()
+                );
+            }
+
+            let segment_align = 1u64 << input_module.reloc_info.segments[segment_index].alignment;
+
+            let mut data_align = segment_align;
+            if data_offset != 0 {
+                // TODO: .isolate_least_significant_one()
+                data_align = data_align.min(1 << data_offset.trailing_zeros());
+            }
+            debug_assert!(data_len != 0, "zero-sized symbols handled previously");
+            data_align = data_align.min(1 << data_len.trailing_zeros());
+
+            let mut has_merged = false;
+            let range_idx = ranges.len();
+            if let Some(back) = ranges.last_mut() {
+                let has_overlap = data_offset < back.input_range.end;
+                if has_overlap {
+                    // we sorted before ingesting, hence the existing range starts earlier
+                    debug_assert!(
+                        back.input_range.start <= data_offset,
+                        "overlapping range goes backwards"
+                    );
+                    let range_offset = data_offset - back.input_range.start;
+                    let range_idx = range_idx - 1; // back of ranges
+
+                    has_merged = true;
+                    back.input_range.end = back.input_range.end.max(data_range.end);
+                    // The range is placed congruent to its input start modulo its alignment, so
+                    // taking the strictest alignment keeps every symbol in it aligned.
+                    back.data_align = back.data_align.max(data_align);
+                    if back.in_module != module_index && back.in_module != MAIN_MODULE {
+                        trace!(
+                            "data symbol {symbol_index} shares bytes {data_range:?} of segment \
+                            {segment_index} with output module {}, emitting them from the main module",
+                            back.in_module
+                        );
+                        back.in_module = MAIN_MODULE;
+                    }
+                    range_lookup.insert(symbol_index, (range_idx, range_offset));
                 }
+            }
+            if !has_merged {
+                ranges.push(LateDataRange {
+                    input_range: data_range,
+                    in_module: module_index,
+                    data_align,
+                    in_module_offset: u64::MAX, // filled in later
+                });
+                range_lookup.insert(symbol_index, (range_idx, 0));
             }
         }
         // finally transform them into output form
@@ -492,9 +530,6 @@ impl DataEmitInfo {
                     range_lookup,
                     base_address,
                 } => {
-                    let segment_alignment =
-                        1u64 << input_module.reloc_info.segments[segment_index].alignment;
-
                     let mut range_emit_order: Vec<_> = (0..ranges.len()).collect();
                     range_emit_order.sort_by_key(|&range_idx| {
                         let range = &ranges[range_idx];
@@ -502,11 +537,17 @@ impl DataEmitInfo {
                     });
                     // reorder symbols per module
                     let mut per_module_size = HashMap::new();
+                    // The first range of a module has the largest alignment (see the sort order above),
+                    // which is all the module's part of the segment needs to be aligned to.
+                    let mut per_module_align = HashMap::new();
                     for &range_idx in &range_emit_order {
                         let range = &mut ranges[range_idx];
                         let module_len = per_module_size.entry(range.in_module).or_insert(0);
+                        per_module_align
+                            .entry(range.in_module)
+                            .or_insert(range.data_align);
                         let data_range = range.input_range.clone();
-                        let data_offset = u64::next_multiple_of(*module_len, range.data_align);
+                        let data_offset = range.align_offset(*module_len);
 
                         // allocate it in that module
                         range.in_module_offset = data_offset;
@@ -525,7 +566,7 @@ impl DataEmitInfo {
                     let mut per_output_offset = HashMap::new();
                     let mut data_offset: u64 = 0;
                     for &(module, module_size) in &per_module_size {
-                        data_offset = data_offset.next_multiple_of(segment_alignment);
+                        data_offset = data_offset.next_multiple_of(per_module_align[&module]);
                         per_output_offset.insert(module, data_offset);
                         data_offset += module_size;
                     }

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -306,6 +306,64 @@ impl LateDataRange {
     }
 }
 
+struct RangeLayout {
+    // indices into the ranges, in the order they are emitted
+    range_emit_order: Vec<usize>,
+    // output module -> offset of its part in the segment
+    per_output_offset: HashMap<usize, u64>,
+    segment_len: u64,
+}
+
+/// Lay out the ranges of one segment: each output module gets a contiguous part of the segment,
+/// and `in_module_offset` of every range is set relative to the part of its module.
+fn layout_ranges(ranges: &mut [LateDataRange]) -> RangeLayout {
+    let mut range_emit_order: Vec<_> = (0..ranges.len()).collect();
+    range_emit_order.sort_by_key(|&range_idx| {
+        let range = &ranges[range_idx];
+        (
+            range.in_module,
+            std::cmp::Reverse(range.data_align),
+            range.input_range.start,
+        )
+    });
+    // reorder symbols per module
+    let mut per_module_size = HashMap::new();
+    // The first range of a module has the largest alignment (see the sort order above),
+    // which is all the module's part of the segment needs to be aligned to.
+    let mut per_module_align = HashMap::new();
+    for &range_idx in &range_emit_order {
+        let range = &mut ranges[range_idx];
+        let module_len = per_module_size.entry(range.in_module).or_insert(0);
+        per_module_align
+            .entry(range.in_module)
+            .or_insert(range.data_align);
+        let data_range = range.input_range.clone();
+        let data_offset = range.align_offset(*module_len);
+
+        // allocate it in that module
+        range.in_module_offset = data_offset;
+        *module_len = data_offset + (data_range.end - data_range.start);
+    }
+
+    // figure out module offsets. Parts with a larger alignment come first, so that padding is
+    // only needed after a part that mixes alignments.
+    let mut per_module_size = per_module_size.into_iter().collect::<Vec<_>>();
+    per_module_size
+        .sort_by_key(|&(module, _)| (std::cmp::Reverse(per_module_align[&module]), module));
+    let mut per_output_offset = HashMap::new();
+    let mut data_offset: u64 = 0;
+    for &(module, module_size) in &per_module_size {
+        data_offset = data_offset.next_multiple_of(per_module_align[&module]);
+        per_output_offset.insert(module, data_offset);
+        data_offset += module_size;
+    }
+    RangeLayout {
+        range_emit_order,
+        per_output_offset,
+        segment_len: data_offset,
+    }
+}
+
 #[derive(Debug)]
 enum DataSegmentEmitInfo {
     // Copy this segment from the input, either in all or a specific output module
@@ -571,29 +629,39 @@ impl DataEmitInfo {
                     range_lookup,
                     base_address,
                 } => {
-                    let mut range_emit_order: Vec<_> = (0..ranges.len()).collect();
-                    range_emit_order.sort_by_key(|&range_idx| {
-                        let range = &ranges[range_idx];
-                        (range.in_module, std::cmp::Reverse(range.data_align), range.input_range.start)
-                    });
-                    // reorder symbols per module
-                    let mut per_module_size = HashMap::new();
-                    // The first range of a module has the largest alignment (see the sort order above),
-                    // which is all the module's part of the segment needs to be aligned to.
-                    let mut per_module_align = HashMap::new();
-                    for &range_idx in &range_emit_order {
-                        let range = &mut ranges[range_idx];
-                        let module_len = per_module_size.entry(range.in_module).or_insert(0);
-                        per_module_align
-                            .entry(range.in_module)
-                            .or_insert(range.data_align);
-                        let data_range = range.input_range.clone();
-                        let data_offset = range.align_offset(*module_len);
-
-                        // allocate it in that module
-                        range.in_module_offset = data_offset;
-                        *module_len = data_offset + (data_range.end - data_range.start);
-                    }
+                    let input_len = wasm_data_len(&input_module.data_segments[segment_index]);
+                    // If we could move other active segments to different base addresses, this segment getting longer
+                    // would not be a problem. Since we can't guarantee this at this point though, don't risk it.
+                    // Overlapping segments *will* overwrite data!
+                    // Instead, as long as the relocated segment is longer than its input, fold the data of the
+                    // smallest module into the main module. That removes the padding between their parts.
+                    // Merged ranges can still need more padding than the input had, so even with all data
+                    // in the main module the segment may not fit; then the whole segment is copied instead.
+                    let layout = loop {
+                        let layout = layout_ranges(&mut ranges);
+                        if layout.segment_len <= input_len {
+                            break Some(layout);
+                        }
+                        let mut per_module_size = HashMap::new();
+                        for range in ranges.iter().filter(|range| range.in_module != MAIN_MODULE) {
+                            *per_module_size.entry(range.in_module).or_insert(0) +=
+                                range.input_range.end - range.input_range.start;
+                        }
+                        let Some((&module, &size)) = per_module_size
+                            .iter()
+                            .min_by_key(|&(&module, &size)| (size, module))
+                        else {
+                            break None;
+                        };
+                        trace!(
+                            "Relocated segment {segment_index} is longer than its input by {}, \
+                            moving the {size} data bytes of output module {module} into the main module",
+                            layout.segment_len - input_len
+                        );
+                        for range in ranges.iter_mut().filter(|range| range.in_module == module) {
+                            range.in_module = MAIN_MODULE;
+                        }
+                    };
 
                     // check that range_lookup completely covers the (non-zero) data segment?
                     // Otherwise there is non-relocated data, which most likely indicates an error.
@@ -601,35 +669,23 @@ impl DataEmitInfo {
                     // Some gaps will exist, introduced by padding for alignment! This padding should be zeroed.
                     // So for the moment, don't bother with this sanity analysis.
 
-                    // figure out module offsets
-                    let mut per_module_size = per_module_size.into_iter().collect::<Vec<_>>();
-                    per_module_size.sort_by_key(|&(m, _)| m);
-                    let mut per_output_offset = HashMap::new();
-                    let mut data_offset: u64 = 0;
-                    for &(module, module_size) in &per_module_size {
-                        data_offset = data_offset.next_multiple_of(per_module_align[&module]);
-                        per_output_offset.insert(module, data_offset);
-                        data_offset += module_size;
-                    }
-                    let segment_len = data_offset;
-
-                    let ranges = DataSegmentEmitInfo::Ranges {
-                        ranges,
-                        base_address,
-                        per_output_offset,
-                        range_lookup,
-                        range_emit_order,
-                    };
-                    // If we could move other active segments to different base addresses, this segment getting longer
-                    // would not be a problem. Since we can't guarantee this at this point though, don't risk it.
-                    // Overlapping segments *will* overwrite data!
-                    if segment_len > wasm_data_len(&input_module.data_segments[segment_index]) {
-                        let overlength = segment_len - wasm_data_len(&input_module.data_segments[segment_index]);
-                        trace!("{ranges:?}");
-                        warn!("Overlong segment {segment_index} by {overlength} after relocation, putting it in main module.");
-                        DataSegmentEmitInfo::FromInputOnlyIn(0)
-                    } else {
-                        ranges
+                    match layout {
+                        Some(RangeLayout {
+                            range_emit_order,
+                            per_output_offset,
+                            ..
+                        }) => DataSegmentEmitInfo::Ranges {
+                            ranges,
+                            base_address,
+                            per_output_offset,
+                            range_lookup,
+                            range_emit_order,
+                        },
+                        None => {
+                            trace!("{ranges:?}");
+                            warn!("Overlong segment {segment_index} after relocation, putting it in main module.");
+                            DataSegmentEmitInfo::FromInputOnlyIn(0)
+                        }
                     }
                 }
             })

--- a/crates/wasm_split_cli/src/split_point.rs
+++ b/crates/wasm_split_cli/src/split_point.rs
@@ -324,7 +324,9 @@ impl SplitModuleIdentifier {
         }
     }
 
-    fn also_in(&mut self, other: &SplitModuleIdentifier) {
+    /// Make this identifier also cover everything that requires `other`: the modules that
+    /// require the result are a superset of those requiring either input.
+    pub(crate) fn also_in(&mut self, other: &SplitModuleIdentifier) {
         let mut needed_by = BTreeSet::new();
         match self {
             SplitModuleIdentifier::Main => return,

--- a/crates/wasm_split_cli/tests/shared_data_symbols_end_to_end.rs
+++ b/crates/wasm_split_cli/tests/shared_data_symbols_end_to_end.rs
@@ -39,6 +39,12 @@
 //! one of the contained symbols belongs to the chunk provisionally chosen for
 //! an intermediate set. Asserts that its splits are still accounted for, so
 //! the range does not end up in a chunk one of them never loads.
+//!
+//! `overlong_segment_folds_the_smallest_split_into_main`: alignment padding
+//! between the parts of the modules makes the relocated segment longer than
+//! its input. Asserts that only the smallest split's data moves into main and
+//! the other split keeps its relocated data, instead of the whole segment
+//! being copied into main unrelocated.
 
 use std::borrow::Cow;
 
@@ -988,4 +994,57 @@ fn chunk_placement_records_every_requiring_split() {
     for split in ["a", "b", "c", "d", "e"] {
         assert_eq!(data_segments(output.split(split)), vec![]);
     }
+}
+
+#[test]
+fn overlong_segment_folds_the_smallest_split_into_main() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // Bytes 3 and 16 are not referenced by any symbol, so two bytes are free for padding.
+    let data = b"Mab.AAAACCCCBBBB.".to_vec();
+    let input = Input {
+        data: data.clone(),
+        alignment: 2,
+        symbols: vec![
+            DataSymbol("main_byte", 0, 1),
+            DataSymbol("a_byte", 1, 1),
+            DataSymbol("a_word1", 4, 4),
+            DataSymbol("a_word2", 8, 4),
+            DataSymbol("b_byte", 2, 1),
+            DataSymbol("b_word", 12, 4),
+        ],
+        funcs: vec![
+            Func(Owner::Main("main_reads"), vec![0]),
+            // The parts of `a` and `b` each mix 4-aligned words with a byte, so the part
+            // following either needs padding: a (9 bytes), pad 3, b (5 bytes), main (1 byte)
+            // needs 18 bytes, one more than the input.
+            Func(Owner::Split("a"), vec![1, 2, 3]),
+            Func(Owner::Split("b"), vec![4, 5]),
+        ],
+        extra_segments: vec![],
+        data_relocs: vec![],
+    };
+    let output = split(&input);
+
+    // `b`, the smaller split, is folded into main: its word first (largest alignment), then the
+    // bytes by input position. `a` keeps its own relocated part, which now fits.
+    assert_eq!(
+        single_data_segment(&output.main),
+        (SEGMENT_BASE, b"BBBBMb".to_vec()),
+        "main should hold its own byte and b's data, packed by alignment",
+    );
+    assert_eq!(
+        exported_function_constants(&output.main, "main_reads"),
+        vec![SEGMENT_BASE + 4]
+    );
+    let split_b = output.split("b");
+    assert_eq!(data_segments(split_b), vec![], "b's data moved into main");
+    assert_some_function_refers_to(split_b, &[SEGMENT_BASE + 5, SEGMENT_BASE]);
+
+    let split_a = output.split("a");
+    let (a_addr, a_bytes) = single_data_segment(split_a);
+    assert_eq!(a_bytes, b"AAAACCCCa");
+    assert_eq!(a_addr % 4, 0, "a's words must stay 4-aligned");
+    assert!(a_addr >= SEGMENT_BASE + 6 && a_addr + 9 <= SEGMENT_BASE + data.len() as u32);
+    assert_some_function_refers_to(split_a, &[a_addr + 8, a_addr, a_addr + 4]);
 }

--- a/crates/wasm_split_cli/tests/shared_data_symbols_end_to_end.rs
+++ b/crates/wasm_split_cli/tests/shared_data_symbols_end_to_end.rs
@@ -40,11 +40,20 @@
 //! an intermediate set. Asserts that its splits are still accounted for, so
 //! the range does not end up in a chunk one of them never loads.
 //!
-//! `overlong_segment_folds_the_smallest_split_into_main`: alignment padding
-//! between the parts of the modules makes the relocated segment longer than
-//! its input. Asserts that only the smallest split's data moves into main and
-//! the other split keeps its relocated data, instead of the whole segment
-//! being copied into main unrelocated.
+//! `mixed_alignments_pack_without_padding_across_modules`: modules mixing
+//! aligned words with bytes. Asserts that the data packs without padding by
+//! emitting one segment per alignment, that every input segment keeps its
+//! index in the outputs and the extra segments are appended.
+//!
+//! `overlong_segment_folds_the_smallest_split_into_main`: a merged range with
+//! an unaligned start makes the relocated segment longer than its input.
+//! Asserts that only the smallest split's data moves into main and the other
+//! split keeps its relocated data, instead of the whole segment being copied
+//! into main unrelocated.
+//!
+//! `overlapping_input_segments_keep_their_order`: two input segments overlap
+//! in memory, which an appended fragment could reorder. Asserts that both are
+//! kept as they are, in their slots.
 
 use std::borrow::Cow;
 
@@ -997,10 +1006,9 @@ fn chunk_placement_records_every_requiring_split() {
 }
 
 #[test]
-fn overlong_segment_folds_the_smallest_split_into_main() {
+fn mixed_alignments_pack_without_padding_across_modules() {
     let _ = tracing_subscriber::fmt::try_init();
 
-    // Bytes 3 and 16 are not referenced by any symbol, so two bytes are free for padding.
     let data = b"Mab.AAAACCCCBBBB.".to_vec();
     let input = Input {
         data: data.clone(),
@@ -1015,9 +1023,6 @@ fn overlong_segment_folds_the_smallest_split_into_main() {
         ],
         funcs: vec![
             Func(Owner::Main("main_reads"), vec![0]),
-            // The parts of `a` and `b` each mix 4-aligned words with a byte, so the part
-            // following either needs padding: a (9 bytes), pad 3, b (5 bytes), main (1 byte)
-            // needs 18 bytes, one more than the input.
             Func(Owner::Split("a"), vec![1, 2, 3]),
             Func(Owner::Split("b"), vec![4, 5]),
         ],
@@ -1026,25 +1031,173 @@ fn overlong_segment_folds_the_smallest_split_into_main() {
     };
     let output = split(&input);
 
-    // `b`, the smaller split, is folded into main: its word first (largest alignment), then the
-    // bytes by input position. `a` keeps its own relocated part, which now fits.
+    // All words come first, then all bytes, so nothing needs padding: 15 of the 17 input bytes
+    // are used, in module order within each alignment.
+    let split_a = output.split("a");
+    let split_b = output.split("b");
     assert_eq!(
-        single_data_segment(&output.main),
-        (SEGMENT_BASE, b"BBBBMb".to_vec()),
-        "main should hold its own byte and b's data, packed by alignment",
+        data_segments(split_a),
+        vec![
+            (SEGMENT_BASE, b"AAAACCCC".to_vec()),
+            (SEGMENT_BASE + 13, b"a".to_vec())
+        ]
+    );
+    assert_eq!(
+        data_segments(split_b),
+        vec![
+            (SEGMENT_BASE + 8, b"BBBB".to_vec()),
+            (SEGMENT_BASE + 14, b"b".to_vec())
+        ]
+    );
+    assert_eq!(
+        data_segments(&output.main),
+        vec![(SEGMENT_BASE + 12, b"M".to_vec())]
+    );
+    assert_some_function_refers_to(
+        split_a,
+        &[SEGMENT_BASE + 13, SEGMENT_BASE, SEGMENT_BASE + 4],
+    );
+    assert_some_function_refers_to(split_b, &[SEGMENT_BASE + 14, SEGMENT_BASE + 8]);
+    assert_eq!(
+        exported_function_constants(&output.main, "main_reads"),
+        vec![SEGMENT_BASE + 12]
+    );
+
+    // The input's only segment keeps index 0 in every module, holding the module's first
+    // fragment; further fragments are appended, and the data count matches.
+    for (name, module, first, extra) in [
+        ("a", split_a, Some(SEGMENT_BASE), vec![SEGMENT_BASE + 13]),
+        (
+            "b",
+            split_b,
+            Some(SEGMENT_BASE + 8),
+            vec![SEGMENT_BASE + 14],
+        ),
+        (
+            "main",
+            output.main.as_slice(),
+            Some(SEGMENT_BASE + 12),
+            vec![],
+        ),
+    ] {
+        let (segments, count) = all_data_segments(module);
+        assert_eq!(segments.len() as u32, count, "{name}: data count");
+        assert_eq!(
+            segments.len(),
+            1 + extra.len(),
+            "{name}: appended fragments"
+        );
+        assert_eq!(
+            segments[0].as_ref().map(|(addr, _)| *addr),
+            first,
+            "{name}: slot of the input segment"
+        );
+        let appended: Vec<u32> = segments[1..]
+            .iter()
+            .map(|segment| {
+                segment
+                    .as_ref()
+                    .expect("appended fragments are not empty")
+                    .0
+            })
+            .collect();
+        assert_eq!(appended, extra, "{name}: appended fragment addresses");
+    }
+}
+
+#[test]
+fn overlong_segment_folds_the_smallest_split_into_main() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // `whole` (split a) starts at offset 1 and contains a 4-aligned word, so its merged range
+    // must be placed at an offset congruent to 1 modulo 4. Bytes 9..12 are unreferenced.
+    let data = b"MABCDEFGH...BBBB".to_vec();
+    let input = Input {
+        data: data.clone(),
+        alignment: 2,
+        symbols: vec![
+            DataSymbol("main_byte", 0, 1),
+            DataSymbol("whole", 1, 8),
+            DataSymbol("word", 4, 4),
+            DataSymbol("b_word", 12, 4),
+        ],
+        funcs: vec![
+            Func(Owner::Main("main_reads"), vec![0]),
+            Func(Owner::Split("a"), vec![1, 2]),
+            Func(Owner::Split("b"), vec![3]),
+        ],
+        extra_segments: vec![],
+        data_relocs: vec![],
+    };
+    let output = split(&input);
+
+    // Without folding: a's range at 1..9, b's word at 12..16, main's byte at 16: one byte too
+    // long. Folding `b`, the smaller split, into main puts its word first at 0..4, then a's
+    // range at 5..13 and main's byte at 13.
+    assert_eq!(
+        data_segments(&output.main),
+        vec![
+            (SEGMENT_BASE, b"BBBB".to_vec()),
+            (SEGMENT_BASE + 13, b"M".to_vec())
+        ],
+        "main should hold b's word and its own byte",
     );
     assert_eq!(
         exported_function_constants(&output.main, "main_reads"),
-        vec![SEGMENT_BASE + 4]
+        vec![SEGMENT_BASE + 13]
     );
     let split_b = output.split("b");
     assert_eq!(data_segments(split_b), vec![], "b's data moved into main");
-    assert_some_function_refers_to(split_b, &[SEGMENT_BASE + 5, SEGMENT_BASE]);
+    assert_some_function_refers_to(split_b, &[SEGMENT_BASE]);
 
     let split_a = output.split("a");
     let (a_addr, a_bytes) = single_data_segment(split_a);
-    assert_eq!(a_bytes, b"AAAACCCCa");
-    assert_eq!(a_addr % 4, 0, "a's words must stay 4-aligned");
-    assert!(a_addr >= SEGMENT_BASE + 6 && a_addr + 9 <= SEGMENT_BASE + data.len() as u32);
-    assert_some_function_refers_to(split_a, &[a_addr + 8, a_addr, a_addr + 4]);
+    assert_eq!(a_bytes, b"ABCDEFGH");
+    assert_eq!(
+        (a_addr + 3) % 4,
+        0,
+        "the word inside a's range must stay 4-aligned"
+    );
+    assert!(a_addr >= SEGMENT_BASE + 4 && a_addr + 8 <= SEGMENT_BASE + 13);
+    assert_some_function_refers_to(split_a, &[a_addr, a_addr + 3]);
+}
+
+#[test]
+fn overlapping_input_segments_keep_their_order() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // Segment 1 at SEGMENT_BASE + 8 overlaps the last byte of segment 0 and is initialized
+    // after it, so that byte must end up as "X". Relocating segment 0 would emit main's "m"
+    // in a segment appended after segment 1.
+    let input = Input {
+        data: b"AAAABBBBm".to_vec(),
+        alignment: 2,
+        symbols: vec![
+            DataSymbol("main_word", 0, 4),
+            DataSymbol("split_word", 4, 4),
+            DataSymbol("main_byte", 8, 1),
+        ],
+        extra_segments: vec![(SEGMENT_BASE + 8, b"X".to_vec(), vec![DataSymbol("x", 0, 1)])],
+        funcs: vec![
+            Func(Owner::Main("main_reads"), vec![0, 2, 3]),
+            Func(Owner::Split("a"), vec![1]),
+        ],
+        data_relocs: vec![],
+    };
+    let output = split(&input);
+
+    assert_eq!(
+        data_segments(&output.main),
+        vec![
+            (SEGMENT_BASE, b"AAAABBBBm".to_vec()),
+            (SEGMENT_BASE + 8, b"X".to_vec())
+        ],
+        "both segments stay as they are, in input order",
+    );
+    assert_eq!(data_segments(output.split("a")), vec![]);
+    assert_some_function_refers_to(output.split("a"), &[SEGMENT_BASE + 4]);
+    assert_eq!(
+        exported_function_constants(&output.main, "main_reads"),
+        vec![SEGMENT_BASE, SEGMENT_BASE + 8, SEGMENT_BASE + 8]
+    );
 }

--- a/crates/wasm_split_cli/tests/shared_data_symbols_end_to_end.rs
+++ b/crates/wasm_split_cli/tests/shared_data_symbols_end_to_end.rs
@@ -54,13 +54,17 @@
 //! `overlapping_input_segments_keep_their_order`: two input segments overlap
 //! in memory, which an appended fragment could reorder. Asserts that both are
 //! kept as they are, in their slots.
+//!
+//! `unknown_segment_base_keeps_active_data_whole`: a segment with a global base address
+//! may overlap the preceding segment. Asserts that no fragments are appended and main
+//! keeps the preceding segment intact at its input address.
 
 use std::borrow::Cow;
 
 use wasm_encoder::{
     CodeSection, ConstExpr, CustomSection, DataSection, Encode, ExportKind, ExportSection,
-    Function, FunctionSection, ImportSection, Instruction, MemorySection, MemoryType, Module,
-    RefType, TableSection, TableType, TypeSection, ValType,
+    Function, FunctionSection, GlobalSection, GlobalType, ImportSection, Instruction,
+    MemorySection, MemoryType, Module, RefType, TableSection, TableType, TypeSection, ValType,
 };
 use wasmparser::{DataKind, Operator, Parser, Payload};
 
@@ -182,7 +186,7 @@ impl Input {
 
     /// Everything but the linking metadata. The metadata is appended
     /// afterwards, which keeps the code offsets computed from this prefix valid.
-    fn build_module_prefix(&self) -> Vec<u8> {
+    fn build_module_prefix(&self, global_segment_base: bool) -> Vec<u8> {
         let splits = self.splits();
         let mut module = Module::new();
 
@@ -227,6 +231,20 @@ impl Input {
         });
         module.section(&memories);
 
+        if global_segment_base {
+            assert_eq!(self.extra_segments.len(), 1);
+            let mut globals = GlobalSection::new();
+            globals.global(
+                GlobalType {
+                    val_type: ValType::I32,
+                    mutable: false,
+                    shared: false,
+                },
+                &ConstExpr::i32_const(self.extra_segments[0].0 as i32),
+            );
+            module.section(&globals);
+        }
+
         let mut exports = ExportSection::new();
         for (i, Func(owner, _)) in self.funcs.iter().enumerate() {
             let func_index = (splits.len() + i) as u32;
@@ -263,7 +281,12 @@ impl Input {
         }
         data.active(0, &ConstExpr::i32_const(SEGMENT_BASE as i32), bytes);
         for (address, bytes, _) in &self.extra_segments {
-            data.active(0, &ConstExpr::i32_const(*address as i32), bytes.clone());
+            let offset = if global_segment_base {
+                ConstExpr::global_get(0)
+            } else {
+                ConstExpr::i32_const(*address as i32)
+            };
+            data.active(0, &offset, bytes.clone());
         }
         module.section(&data);
 
@@ -271,7 +294,12 @@ impl Input {
     }
 
     fn build_wasm(&self) -> Vec<u8> {
-        let mut wasm = self.build_module_prefix();
+        self.build_wasm_with_segment_base(false)
+    }
+
+    /// Use a global for the extra segments' base address to exercise unknown offsets.
+    fn build_wasm_with_segment_base(&self, global_segment_base: bool) -> Vec<u8> {
+        let mut wasm = self.build_module_prefix(global_segment_base);
         let (code_section_index, immediates) = locate_code_immediates(&wasm);
         let (data_section_index, data_start) = locate_data_segment(&wasm);
         let reloc_symbols: Vec<u32> = self
@@ -446,12 +474,15 @@ struct Output {
 
 fn split(input: &Input) -> Output {
     let wasm = input.build_wasm();
+    split_wasm(&wasm)
+}
 
+fn split_wasm(wasm: &[u8]) -> Output {
     let mut tmp = tempfile::tempdir().expect("create tmpdir");
     tmp.disable_cleanup(true);
     let main_out = tmp.path().join("main.wasm");
 
-    let mut opts = Options::new(&wasm);
+    let mut opts = Options::new(wasm);
     opts.output_dir = tmp.path();
     opts.main_out_path = &main_out;
 
@@ -1199,5 +1230,76 @@ fn overlapping_input_segments_keep_their_order() {
     assert_eq!(
         exported_function_constants(&output.main, "main_reads"),
         vec![SEGMENT_BASE, SEGMENT_BASE + 8, SEGMENT_BASE + 8]
+    );
+}
+
+#[test]
+fn unknown_segment_base_keeps_active_data_whole() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // Fragmenting segment 0 would append main's byte after segment 1 and overwrite its X.
+    let input = Input {
+        data: b"AAAABBBBm".to_vec(),
+        alignment: 2,
+        symbols: vec![
+            DataSymbol("main_word", 0, 4),
+            DataSymbol("split_word", 4, 4),
+            DataSymbol("main_byte", 8, 1),
+        ],
+        extra_segments: vec![(SEGMENT_BASE + 8, b"X".to_vec(), vec![])],
+        funcs: vec![
+            Func(Owner::Main("main_reads"), vec![0, 2]),
+            Func(Owner::Split("a"), vec![1]),
+        ],
+        data_relocs: vec![],
+    };
+    let wasm = input.build_wasm_with_segment_base(true);
+    wasmparser::Validator::new()
+        .validate_all(&wasm)
+        .expect("valid input with a global segment base");
+    let output = split_wasm(&wasm);
+    let input_segment_count = 1 + input.extra_segments.len();
+
+    for (is_main, module) in std::iter::once((true, &output.main))
+        .chain(output.splits.iter().map(|(_, module)| (false, module)))
+        .chain(output.chunks.iter().map(|module| (false, module)))
+    {
+        for payload in Parser::new(0).parse_all(module) {
+            match payload.expect("valid wasm") {
+                Payload::DataCountSection { count, .. } => {
+                    assert_eq!(count as usize, input_segment_count, "data count");
+                }
+                Payload::DataSection(reader) => {
+                    let segments = reader.into_iter().collect::<Result<Vec<_>, _>>().unwrap();
+                    assert_eq!(segments.len(), input_segment_count, "no appended fragments");
+                    let DataKind::Active { offset_expr, .. } = &segments[0].kind else {
+                        panic!("segment 0 stays active");
+                    };
+                    assert!(matches!(
+                        offset_expr.get_operators_reader().read().unwrap(),
+                        Operator::I32Const { value } if value as u32 == SEGMENT_BASE
+                    ));
+                    if is_main {
+                        assert_eq!(segments[0].data, input.data, "segment 0 stays intact");
+                        assert_eq!(segments[1].data, b"X");
+                        let DataKind::Active { offset_expr, .. } = &segments[1].kind else {
+                            panic!("segment 1 stays active");
+                        };
+                        assert!(matches!(
+                            offset_expr.get_operators_reader().read().unwrap(),
+                            Operator::GlobalGet { global_index: 0 }
+                        ));
+                    } else {
+                        assert!(segments.iter().all(|segment| segment.data.is_empty()));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    assert_some_function_refers_to(output.split("a"), &[SEGMENT_BASE + 4]);
+    assert_eq!(
+        exported_function_constants(&output.main, "main_reads"),
+        vec![SEGMENT_BASE, SEGMENT_BASE + 8]
     );
 }

--- a/crates/wasm_split_cli/tests/shared_data_symbols_end_to_end.rs
+++ b/crates/wasm_split_cli/tests/shared_data_symbols_end_to_end.rs
@@ -16,6 +16,14 @@
 //! `overlapping_symbols_keep_the_strictest_alignment`: a 4-aligned word is
 //! overlapped by a longer, unaligned string. Asserts that the merged bytes
 //! are placed so that the word stays aligned.
+//!
+//! `pointer_inside_a_contained_symbol_pulls_its_target_into_main`: the main
+//! module uses the tail of a split's symbol, and that tail holds a pointer.
+//! Asserts that the pointer's target is available to main.
+//!
+//! `relocation_crossing_an_inner_symbol_belongs_to_the_containing_symbol`: a
+//! pointer straddles the boundary of a symbol nested in another. Asserts that
+//! it is attributed to the containing symbol instead of being rejected.
 
 use std::borrow::Cow;
 
@@ -685,4 +693,91 @@ fn overlapping_symbols_keep_the_strictest_alignment() {
         exported_function_constants(&output.main, "main_reads"),
         vec![main_addr]
     );
+}
+
+#[test]
+fn pointer_inside_a_contained_symbol_pulls_its_target_into_main() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // outer = "ABCD" + pointer; the pointer is the tail that main uses, and it points at target.
+    let mut data = b"ABCD".to_vec();
+    data.extend_from_slice(&[0; 4]); // pointer, written by the builder
+    data.extend_from_slice(&9u32.to_le_bytes());
+    let input = Input {
+        data: data.clone(),
+        alignment: 2,
+        symbols: vec![
+            DataSymbol("outer", 0, 8),
+            DataSymbol("tail", 4, 4),
+            DataSymbol("target", 8, 4),
+        ],
+        funcs: vec![
+            Func(Owner::Main("main_reads"), vec![1]),
+            Func(Owner::Split("a"), vec![0]),
+        ],
+        extra_segments: vec![],
+        data_relocs: vec![(4, 2)],
+    };
+    let output = split(&input);
+
+    // Main reads the pointer, so the target must be there before the split loads: everything
+    // ends up in main, with the pointer relocated to the target's (unchanged) address.
+    let (main_addr, main_bytes) = single_data_segment(&output.main);
+    assert_eq!(main_addr, SEGMENT_BASE);
+    let mut expected = data.clone();
+    expected[4..8].copy_from_slice(&(SEGMENT_BASE + 8).to_le_bytes());
+    assert_eq!(
+        main_bytes, expected,
+        "main must hold outer, its pointer and the target"
+    );
+    assert_eq!(
+        exported_function_constants(&output.main, "main_reads"),
+        vec![SEGMENT_BASE + 4]
+    );
+    let split_a = output.split("a");
+    assert_eq!(
+        data_segments(split_a),
+        vec![],
+        "a shares all its data with main"
+    );
+    assert_some_function_refers_to(split_a, &[SEGMENT_BASE]);
+}
+
+#[test]
+fn relocation_crossing_an_inner_symbol_belongs_to_the_containing_symbol() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // outer = "AB" + pointer + "CD", inner = the last four bytes of outer, so the pointer
+    // straddles inner's start. Only outer contains it, so its target follows outer to main.
+    let mut data = b"AB".to_vec();
+    data.extend_from_slice(&[0; 4]); // pointer, written by the builder
+    data.extend_from_slice(b"CD");
+    data.extend_from_slice(&9u32.to_le_bytes()); // target
+    let input = Input {
+        data: data.clone(),
+        alignment: 2,
+        symbols: vec![
+            DataSymbol("outer", 0, 8),
+            DataSymbol("inner", 4, 4),
+            DataSymbol("target", 8, 4),
+        ],
+        extra_segments: vec![],
+        funcs: vec![
+            Func(Owner::Main("main_reads"), vec![0]),
+            Func(Owner::Split("a"), vec![1]),
+        ],
+        data_relocs: vec![(2, 2)],
+    };
+    let output = split(&input);
+
+    let (main_addr, main_bytes) = single_data_segment(&output.main);
+    assert_eq!(main_addr, SEGMENT_BASE);
+    let mut expected = data.clone();
+    expected[2..6].copy_from_slice(&(SEGMENT_BASE + 8).to_le_bytes());
+    assert_eq!(
+        main_bytes, expected,
+        "main must hold outer, its pointer and the target"
+    );
+    assert_eq!(data_segments(output.split("a")), vec![]);
+    assert_some_function_refers_to(output.split("a"), &[SEGMENT_BASE + 4]);
 }

--- a/crates/wasm_split_cli/tests/shared_data_symbols_end_to_end.rs
+++ b/crates/wasm_split_cli/tests/shared_data_symbols_end_to_end.rs
@@ -24,6 +24,21 @@
 //! `relocation_crossing_an_inner_symbol_belongs_to_the_containing_symbol`: a
 //! pointer straddles the boundary of a symbol nested in another. Asserts that
 //! it is attributed to the containing symbol instead of being rejected.
+//!
+//! `data_shared_between_splits_is_emitted_from_their_chunk`: split `a` uses a
+//! whole string, splits `a` and `b` both use its tail. Asserts that the whole
+//! string is emitted from the chunk shared by `a` and `b`, not from main.
+//!
+//! `chunk_placement_uses_the_exact_chunk_of_all_requiring_splits`: a split's
+//! symbol contains three symbols shared with other splits, so the merged range
+//! is required by a growing set of splits. Asserts that the range ends up in
+//! the chunk shared by exactly the final set, even though no chunk matched an
+//! intermediate set.
+//!
+//! `chunk_placement_records_every_requiring_split`: like the previous one, but
+//! one of the contained symbols belongs to the chunk provisionally chosen for
+//! an intermediate set. Asserts that its splits are still accounted for, so
+//! the range does not end up in a chunk one of them never loads.
 
 use std::borrow::Cow;
 
@@ -780,4 +795,197 @@ fn relocation_crossing_an_inner_symbol_belongs_to_the_containing_symbol() {
     );
     assert_eq!(data_segments(output.split("a")), vec![]);
     assert_some_function_refers_to(output.split("a"), &[SEGMENT_BASE + 4]);
+}
+
+#[test]
+fn data_shared_between_splits_is_emitted_from_their_chunk() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let mut data = SHARED.to_vec();
+    data.extend_from_slice(SPLIT_ONLY);
+    data.extend_from_slice(MAIN_ONLY);
+    let main_only_offset = SHARED.len() + SPLIT_ONLY.len();
+    let input = Input {
+        data,
+        alignment: 0,
+        symbols: vec![
+            DataSymbol("shared_full", 0, SHARED.len()),
+            DataSymbol(
+                "shared_tail",
+                SHARED_TAIL_OFFSET,
+                SHARED.len() - SHARED_TAIL_OFFSET,
+            ),
+            DataSymbol("split_only", SHARED.len(), SPLIT_ONLY.len()),
+            DataSymbol("main_only", main_only_offset, MAIN_ONLY.len()),
+        ],
+        funcs: vec![
+            Func(Owner::Main("main_reads"), vec![3]),
+            // `a` uses the whole string, `a` and `b` its tail: the tail is shared by both
+            // splits and lives in their chunk. The whole string overlaps it and must follow.
+            Func(Owner::Split("a"), vec![0, 1]),
+            Func(Owner::Split("b"), vec![1, 2]),
+        ],
+        extra_segments: vec![],
+        data_relocs: vec![],
+    };
+    let output = split(&input);
+    let segment_end = SEGMENT_BASE + input.data.len() as u32;
+
+    // main only holds its own bytes
+    assert_eq!(
+        single_data_segment(&output.main),
+        (SEGMENT_BASE, MAIN_ONLY.to_vec()),
+        "main module should contain exactly its own bytes",
+    );
+    assert_eq!(
+        exported_function_constants(&output.main, "main_reads"),
+        vec![SEGMENT_BASE]
+    );
+
+    // the whole shared string is in the one chunk shared by `a` and `b`
+    let [chunk] = output.chunks.as_slice() else {
+        panic!("expected exactly one chunk, got {}", output.chunks.len());
+    };
+    let (shared_addr, shared_bytes) = single_data_segment(chunk);
+    assert_eq!(shared_bytes, SHARED);
+    let shared_tail_addr = shared_addr + SHARED_TAIL_OFFSET as u32;
+
+    // `a` has no data of its own left, `b` keeps its own bytes
+    let split_a = output.split("a");
+    assert_eq!(data_segments(split_a), vec![], "all of a's data is shared");
+    assert_some_function_refers_to(split_a, &[shared_addr, shared_tail_addr]);
+
+    let split_b = output.split("b");
+    let (split_only_addr, split_only_bytes) = single_data_segment(split_b);
+    assert_eq!(split_only_bytes, SPLIT_ONLY);
+    assert_some_function_refers_to(split_b, &[shared_tail_addr, split_only_addr]);
+
+    // everything stays inside the input segment, without overlaps
+    let mut regions = [
+        (SEGMENT_BASE, MAIN_ONLY.len() as u32),
+        (shared_addr, SHARED.len() as u32),
+        (split_only_addr, SPLIT_ONLY.len() as u32),
+    ];
+    regions.sort();
+    for window in regions.windows(2) {
+        let [(start, len), (next, _)] = window else {
+            unreachable!()
+        };
+        assert!(start + len <= *next, "regions overlap: {regions:?}");
+    }
+    let (last, len) = regions[2];
+    assert!(last + len <= segment_end, "segment grew past its input");
+}
+
+#[test]
+fn chunk_placement_uses_the_exact_chunk_of_all_requiring_splits() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // `outer` (split a) contains `i1` (also b), `i2` (also c) and `i3` (also b, c, e). The
+    // range is therefore required by {a,b}, then {a,b,c}, then {a,b,c,e}. Only the first and
+    // the last set have a chunk; {a,b,c} does not, but its superset {a,b,c,d} (holding `w`)
+    // does. Choosing that superset for the intermediate set must not send the range to main
+    // once `i3` is merged.
+    let data = b"iiiijjjjkkkkWWM.".to_vec();
+    let input = Input {
+        data: data.clone(),
+        alignment: 0,
+        symbols: vec![
+            DataSymbol("outer", 0, 12),
+            DataSymbol("i1", 0, 4),
+            DataSymbol("i2", 4, 4),
+            DataSymbol("i3", 8, 4),
+            DataSymbol("w", 12, 2),
+            DataSymbol("m", 14, 1),
+        ],
+        funcs: vec![
+            Func(Owner::Main("main_reads"), vec![5]),
+            Func(Owner::Split("a"), vec![0, 4]),
+            Func(Owner::Split("b"), vec![1, 3, 4]),
+            Func(Owner::Split("c"), vec![2, 3, 4]),
+            Func(Owner::Split("d"), vec![4]),
+            Func(Owner::Split("e"), vec![3]),
+        ],
+        extra_segments: vec![],
+        data_relocs: vec![],
+    };
+    let output = split(&input);
+
+    assert_eq!(
+        single_data_segment(&output.main),
+        (SEGMENT_BASE, b"M".to_vec()),
+        "main should only hold its own byte",
+    );
+    // the data of each chunk; chunks whose symbols all moved elsewhere have none
+    let chunk_data: Vec<Vec<Vec<u8>>> = output
+        .chunks
+        .iter()
+        .map(|chunk| {
+            data_segments(chunk)
+                .into_iter()
+                .map(|(_, bytes)| bytes)
+                .collect()
+        })
+        .collect();
+    assert!(
+        chunk_data.contains(&vec![b"iiiijjjjkkkk".to_vec()]),
+        "the shared range should be in a chunk of its own, got {chunk_data:?}",
+    );
+    assert!(
+        chunk_data.contains(&vec![b"WW".to_vec()]),
+        "w should be in the {{a,b,c,d}} chunk on its own, got {chunk_data:?}",
+    );
+    for split in ["a", "b", "c", "d", "e"] {
+        assert_eq!(
+            data_segments(output.split(split)),
+            vec![],
+            "{split} shares all its data"
+        );
+    }
+}
+
+#[test]
+fn chunk_placement_records_every_requiring_split() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // `outer` (split a) contains `i1` (also b), `i2` (also c), `i3` (also b, c, d) and `i4`
+    // (also b, c, e). After `i2` the range is required by {a,b,c}, for which the superset chunk
+    // {a,b,c,d} (holding `i3`) is chosen. `i3`'s owner is that very chunk, so `d` must still be
+    // recorded: after `i4` the range is required by {a,b,c,d,e}, which only main satisfies.
+    let data = b"iiiijjjjkkkkllllM".to_vec();
+    let input = Input {
+        data: data.clone(),
+        alignment: 0,
+        symbols: vec![
+            DataSymbol("outer", 0, 16),
+            DataSymbol("i1", 0, 4),
+            DataSymbol("i2", 4, 4),
+            DataSymbol("i3", 8, 4),
+            DataSymbol("i4", 12, 4),
+            DataSymbol("m", 16, 1),
+        ],
+        extra_segments: vec![],
+        funcs: vec![
+            Func(Owner::Main("main_reads"), vec![5]),
+            Func(Owner::Split("a"), vec![0]),
+            Func(Owner::Split("b"), vec![1, 3, 4]),
+            Func(Owner::Split("c"), vec![2, 3, 4]),
+            Func(Owner::Split("d"), vec![3]),
+            Func(Owner::Split("e"), vec![4]),
+        ],
+        data_relocs: vec![],
+    };
+    let output = split(&input);
+
+    assert_eq!(
+        single_data_segment(&output.main),
+        (SEGMENT_BASE, data),
+        "the range is needed by every split, so only main can hold it",
+    );
+    for chunk in &output.chunks {
+        assert_eq!(data_segments(chunk), vec![], "no chunk may hold the range");
+    }
+    for split in ["a", "b", "c", "d", "e"] {
+        assert_eq!(data_segments(output.split(split)), vec![]);
+    }
 }

--- a/crates/wasm_split_cli/tests/shared_data_symbols_end_to_end.rs
+++ b/crates/wasm_split_cli/tests/shared_data_symbols_end_to_end.rs
@@ -1,0 +1,688 @@
+//! Builds minimal splittable wasm modules whose data segment holds symbols
+//! that share bytes - the layout wasm-ld produces when it tail-merges strings
+//! while optimizing - and runs the full `wasm_split_cli_support::transform()`
+//! pipeline on them.
+//! `shared_data_symbols_are_emitted_once_and_split_data_is_relocated`: the
+//! split module uses a whole string, the main module a symbol for its tail.
+//! Asserts that the shared bytes are emitted exactly once, from the main
+//! module, that both functions refer to that one copy, and that the bytes
+//! only the split module uses are relocated into the split module.
+//!
+//! Before the fix, the shared bytes were allocated once per module, the
+//! segment became longer than its input, and the *whole* segment was put into
+//! the main module, so nothing was ever relocated into split modules of
+//! release builds (leptos-rs/cargo-leptos#679).
+//!
+//! `overlapping_symbols_keep_the_strictest_alignment`: a 4-aligned word is
+//! overlapped by a longer, unaligned string. Asserts that the merged bytes
+//! are placed so that the word stays aligned.
+
+use std::borrow::Cow;
+
+use wasm_encoder::{
+    CodeSection, ConstExpr, CustomSection, DataSection, Encode, ExportKind, ExportSection,
+    Function, FunctionSection, ImportSection, Instruction, MemorySection, MemoryType, Module,
+    RefType, TableSection, TableType, TypeSection, ValType,
+};
+use wasmparser::{DataKind, Operator, Parser, Payload};
+
+use wasm_split_cli_support::{transform, Options};
+
+#[path = "../src/magic_constants.rs"]
+mod magic_constants;
+
+const SPLIT_HASH: &str = "00000000000000000000000000000000";
+
+/// Where the input's only data segment is placed in memory.
+const SEGMENT_BASE: u32 = 1024;
+/// The whole string; other symbols use its tail.
+const SHARED: &[u8] = b"shared-bytes\0";
+const SHARED_TAIL_OFFSET: usize = 7; // "bytes\0"
+/// Bytes only one module refers to.
+const SPLIT_ONLY: &[u8] = b"split-only\0";
+const MAIN_ONLY: &[u8] = b"main-only\0";
+
+/// `R_WASM_MEMORY_ADDR_LEB`
+const R_WASM_MEMORY_ADDR_LEB: u8 = 3;
+/// `R_WASM_MEMORY_ADDR_I32`
+const R_WASM_MEMORY_ADDR_I32: u8 = 5;
+
+/// A defined data symbol: `(name, offset in the segment, size)`.
+struct DataSymbol(&'static str, usize, usize);
+
+/// Which module a function belongs to.
+enum Owner {
+    /// Exported from the main module under this name.
+    Main(&'static str),
+    /// The entry of the split with this name.
+    Split(&'static str),
+}
+
+/// A defined function that refers to data symbols (by index into
+/// [`Input::symbols`]) through `i32.const` immediates, in this order.
+struct Func(Owner, Vec<usize>);
+
+struct Input {
+    data: Vec<u8>,
+    /// log2 of the segment's alignment
+    alignment: u32,
+    symbols: Vec<DataSymbol>,
+    /// Further data segments: `(address, bytes, symbols relative to the segment)`. Their
+    /// symbols are numbered after [`Input::symbols`], in order.
+    extra_segments: Vec<(u32, Vec<u8>, Vec<DataSymbol>)>,
+    funcs: Vec<Func>,
+    /// Pointers inside the data: `(offset in the segment, index of the symbol pointed to)`.
+    /// The builder writes the input address of the symbol there.
+    data_relocs: Vec<(usize, usize)>,
+}
+
+fn uleb(mut value: u32, out: &mut Vec<u8>) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value == 0 {
+            out.push(byte);
+            return;
+        }
+        out.push(byte | 0x80);
+    }
+}
+
+fn name(s: &str, out: &mut Vec<u8>) {
+    uleb(s.len() as u32, out);
+    out.extend_from_slice(s.as_bytes());
+}
+
+/// `i32.const` with a 5-byte padded immediate, as emitted for relocatable code.
+fn padded_i32_const(mut value: u32) -> [u8; 6] {
+    let mut bytes = [0x41, 0, 0, 0, 0, 0];
+    for byte in &mut bytes[1..5] {
+        *byte = (value & 0x7f) as u8 | 0x80;
+        value >>= 7;
+    }
+    bytes[5] = (value & 0x7f) as u8;
+    bytes
+}
+
+fn split_import_name(split: &str) -> String {
+    format!("__wasm_split_00{split}00_import_{SPLIT_HASH}")
+}
+
+fn split_export_name(split: &str) -> String {
+    format!("__wasm_split_00{split}00_export_{SPLIT_HASH}")
+}
+
+impl Input {
+    /// All symbols as `(segment index, symbol)`, in symbol table order.
+    fn all_symbols(&self) -> Vec<(usize, &DataSymbol)> {
+        let mut symbols: Vec<_> = self.symbols.iter().map(|symbol| (0, symbol)).collect();
+        for (i, (_, _, segment_symbols)) in self.extra_segments.iter().enumerate() {
+            symbols.extend(segment_symbols.iter().map(|symbol| (1 + i, symbol)));
+        }
+        symbols
+    }
+
+    /// The input address of a symbol, by index into [`Input::all_symbols`].
+    fn symbol_address(&self, symbol: usize) -> u32 {
+        let (segment, DataSymbol(_, offset, _)) = self.all_symbols()[symbol];
+        let base = match segment {
+            0 => SEGMENT_BASE,
+            i => self.extra_segments[i - 1].0,
+        };
+        base + *offset as u32
+    }
+
+    fn splits(&self) -> Vec<&'static str> {
+        self.funcs
+            .iter()
+            .filter_map(|Func(owner, _)| match owner {
+                Owner::Split(split) => Some(*split),
+                Owner::Main(_) => None,
+            })
+            .collect()
+    }
+
+    /// Everything but the linking metadata. The metadata is appended
+    /// afterwards, which keeps the code offsets computed from this prefix valid.
+    fn build_module_prefix(&self) -> Vec<u8> {
+        let splits = self.splits();
+        let mut module = Module::new();
+
+        let mut types = TypeSection::new();
+        types.ty().function([], [ValType::I32]);
+        module.section(&types);
+
+        // One placeholder import per split, then the defined functions.
+        let mut imports = ImportSection::new();
+        for split in &splits {
+            imports.import(
+                magic_constants::PLACEHOLDER_IMPORT_MODULE,
+                &split_import_name(split),
+                wasm_encoder::EntityType::Function(0),
+            );
+        }
+        module.section(&imports);
+
+        let mut functions = FunctionSection::new();
+        for _ in &self.funcs {
+            functions.function(0);
+        }
+        module.section(&functions);
+
+        let mut tables = TableSection::new();
+        tables.table(TableType {
+            element_type: RefType::FUNCREF,
+            minimum: 1,
+            maximum: Some(1),
+            table64: false,
+            shared: false,
+        });
+        module.section(&tables);
+
+        let mut memories = MemorySection::new();
+        memories.memory(MemoryType {
+            minimum: 1,
+            maximum: None,
+            memory64: false,
+            shared: false,
+            page_size_log2: None,
+        });
+        module.section(&memories);
+
+        let mut exports = ExportSection::new();
+        for (i, Func(owner, _)) in self.funcs.iter().enumerate() {
+            let func_index = (splits.len() + i) as u32;
+            let export_name = match owner {
+                Owner::Main(export) => export.to_string(),
+                Owner::Split(split) => split_export_name(split),
+            };
+            exports.export(&export_name, ExportKind::Func, func_index);
+        }
+        exports.export("__indirect_function_table", ExportKind::Table, 0);
+        exports.export("memory", ExportKind::Memory, 0);
+        module.section(&exports);
+
+        let mut code = CodeSection::new();
+        for Func(_, refs) in &self.funcs {
+            // `i32.const a; drop; ...; i32.const z; end`: refers to every symbol, returns the last.
+            let mut func = Function::new([]);
+            for (i, &symbol) in refs.iter().enumerate() {
+                if i != 0 {
+                    func.instruction(&Instruction::Drop);
+                }
+                func.raw(padded_i32_const(self.symbol_address(symbol)));
+            }
+            func.instruction(&Instruction::End);
+            code.function(&func);
+        }
+        module.section(&code);
+
+        let mut data = DataSection::new();
+        let mut bytes = self.data.clone();
+        for &(offset, symbol) in &self.data_relocs {
+            let address = self.symbol_address(symbol);
+            bytes[offset..offset + 4].copy_from_slice(&address.to_le_bytes());
+        }
+        data.active(0, &ConstExpr::i32_const(SEGMENT_BASE as i32), bytes);
+        for (address, bytes, _) in &self.extra_segments {
+            data.active(0, &ConstExpr::i32_const(*address as i32), bytes.clone());
+        }
+        module.section(&data);
+
+        module.finish()
+    }
+
+    fn build_wasm(&self) -> Vec<u8> {
+        let mut wasm = self.build_module_prefix();
+        let (code_section_index, immediates) = locate_code_immediates(&wasm);
+        let (data_section_index, data_start) = locate_data_segment(&wasm);
+        let reloc_symbols: Vec<u32> = self
+            .funcs
+            .iter()
+            .flat_map(|Func(_, refs)| refs.iter().map(|&symbol| 1 + symbol as u32))
+            .collect();
+        assert_eq!(immediates.len(), reloc_symbols.len());
+
+        // "linking" section, version 2
+        let mut linking = vec![];
+        uleb(2, &mut linking);
+        {
+            // WASM_SEGMENT_INFO
+            let mut payload = vec![];
+            uleb(1 + self.extra_segments.len() as u32, &mut payload);
+            for _ in 0..=self.extra_segments.len() {
+                name(".rodata", &mut payload);
+                uleb(self.alignment, &mut payload); // alignment (log2)
+                uleb(0, &mut payload); // flags
+            }
+            linking.push(5);
+            uleb(payload.len() as u32, &mut linking);
+            linking.extend_from_slice(&payload);
+        }
+        {
+            // WASM_SYMBOL_TABLE
+            const SYMTAB_DATA: u8 = 1;
+            const SYMTAB_TABLE: u8 = 5;
+            const WASM_SYM_BINDING_LOCAL: u32 = 2;
+            let all_symbols = self.all_symbols();
+            let mut payload = vec![];
+            uleb(1 + all_symbols.len() as u32, &mut payload);
+            // 0: the indirect function table
+            payload.push(SYMTAB_TABLE);
+            uleb(WASM_SYM_BINDING_LOCAL, &mut payload);
+            uleb(0, &mut payload);
+            name("__indirect_function_table", &mut payload);
+            // 1..: data symbols, `(segment, offset, size)`
+            for (segment, DataSymbol(symbol_name, offset, size)) in all_symbols {
+                payload.push(SYMTAB_DATA);
+                uleb(WASM_SYM_BINDING_LOCAL, &mut payload);
+                name(symbol_name, &mut payload);
+                uleb(segment as u32, &mut payload);
+                uleb(*offset as u32, &mut payload);
+                uleb(*size as u32, &mut payload);
+            }
+            linking.push(8);
+            uleb(payload.len() as u32, &mut linking);
+            linking.extend_from_slice(&payload);
+        }
+        wasm.push(0);
+        CustomSection {
+            name: Cow::Borrowed("linking"),
+            data: Cow::Owned(linking),
+        }
+        .encode(&mut wasm);
+
+        // wasm-split marker: [tag u8][payload_len uleb][payload]. (see wasm_split/../marker.rs)
+        let ws_payload = [1u8, 1u8, 1u8];
+        wasm.push(0);
+        CustomSection {
+            name: Cow::Borrowed(magic_constants::LINK_SECTION),
+            data: Cow::Borrowed(&ws_payload),
+        }
+        .encode(&mut wasm);
+
+        // "reloc.CODE": one entry per `i32.const` immediate
+        let mut relocs = vec![];
+        uleb(code_section_index, &mut relocs);
+        uleb(immediates.len() as u32, &mut relocs);
+        for (offset, symbol) in immediates.into_iter().zip(reloc_symbols) {
+            relocs.push(R_WASM_MEMORY_ADDR_LEB);
+            uleb(offset, &mut relocs);
+            uleb(symbol, &mut relocs);
+            relocs.push(0); // addend
+        }
+        wasm.push(0);
+        CustomSection {
+            name: Cow::Borrowed("reloc.CODE"),
+            data: Cow::Owned(relocs),
+        }
+        .encode(&mut wasm);
+
+        // "reloc.DATA": one entry per pointer inside the data
+        if !self.data_relocs.is_empty() {
+            let mut relocs = vec![];
+            uleb(data_section_index, &mut relocs);
+            uleb(self.data_relocs.len() as u32, &mut relocs);
+            for &(offset, symbol) in &self.data_relocs {
+                relocs.push(R_WASM_MEMORY_ADDR_I32);
+                uleb(data_start + offset as u32, &mut relocs);
+                uleb(1 + symbol as u32, &mut relocs);
+                relocs.push(0); // addend
+            }
+            wasm.push(0);
+            CustomSection {
+                name: Cow::Borrowed("reloc.DATA"),
+                data: Cow::Owned(relocs),
+            }
+            .encode(&mut wasm);
+        }
+
+        for payload in Parser::new(0).parse_all(&wasm) {
+            payload.expect("input wasm is valid");
+        }
+        wasm
+    }
+}
+
+/// `(section index of the code section, code relocation offsets of every
+/// `i32.const` immediate, in function order)`.
+fn locate_code_immediates(wasm: &[u8]) -> (u32, Vec<u32>) {
+    let mut section_index: u32 = 0;
+    let mut code_section: Option<(u32, u64)> = None;
+    let mut immediates = vec![];
+    for payload in Parser::new(0).parse_all(wasm) {
+        let payload = payload.expect("valid wasm");
+        if let Some((_, range)) = payload.as_section() {
+            if let Payload::CodeSectionStart { .. } = payload {
+                code_section = Some((section_index, range.start));
+            }
+            section_index += 1;
+        }
+        if let Payload::CodeSectionEntry(body) = payload {
+            let (_, content_start) = code_section.expect("code section starts before entries");
+            let mut ops = body.get_operators_reader().expect("operators");
+            while !ops.eof() {
+                let (op, offset) = ops.read_with_offset().expect("op");
+                if let Operator::I32Const { .. } = op {
+                    // the immediate follows the one-byte opcode
+                    immediates.push((offset + 1 - content_start) as u32);
+                }
+            }
+        }
+    }
+    let (index, _) = code_section.expect("code section");
+    (index, immediates)
+}
+
+/// `(section index of the data section, data relocation offset of the first
+/// byte of the only data segment)`.
+fn locate_data_segment(wasm: &[u8]) -> (u32, u32) {
+    let mut section_index: u32 = 0;
+    for payload in Parser::new(0).parse_all(wasm) {
+        let payload = payload.expect("valid wasm");
+        let Some((_, range)) = payload.as_section() else {
+            continue;
+        };
+        if let Payload::DataSection(reader) = &payload {
+            let segment = reader
+                .clone()
+                .into_iter()
+                .next()
+                .expect("a data segment")
+                .expect("valid data segment");
+            let data_start = segment.range.end - segment.data.len() as u64;
+            return (section_index, (data_start - range.start) as u32);
+        }
+        section_index += 1;
+    }
+    panic!("no data section");
+}
+
+/// The output modules of `transform` on an [`Input`].
+struct Output {
+    main: Vec<u8>,
+    /// by split name
+    splits: Vec<(String, Vec<u8>)>,
+    chunks: Vec<Vec<u8>>,
+}
+
+fn split(input: &Input) -> Output {
+    let wasm = input.build_wasm();
+
+    let mut tmp = tempfile::tempdir().expect("create tmpdir");
+    tmp.disable_cleanup(true);
+    let main_out = tmp.path().join("main.wasm");
+
+    let mut opts = Options::new(&wasm);
+    opts.output_dir = tmp.path();
+    opts.main_out_path = &main_out;
+
+    let output = transform(opts).expect("transform succeeds");
+
+    let main = std::fs::read(&main_out).expect("read main.wasm output");
+    let mut splits = vec![];
+    let mut chunks = vec![];
+    for path in &output.split_modules {
+        let file_name = path.file_name().unwrap().to_string_lossy();
+        let bytes = std::fs::read(path).expect("read output module");
+        if let Some(split) = file_name
+            .strip_prefix("split_")
+            .and_then(|rest| rest.strip_suffix(".wasm"))
+        {
+            splits.push((split.to_string(), bytes));
+        } else if file_name.starts_with("chunk_") {
+            chunks.push(bytes);
+        } else {
+            panic!("unexpected output module {file_name}");
+        }
+    }
+
+    tmp.disable_cleanup(false);
+    Output {
+        main,
+        splits,
+        chunks,
+    }
+}
+
+impl Output {
+    fn split(&self, name: &str) -> &[u8] {
+        &self
+            .splits
+            .iter()
+            .find(|(split, _)| split == name)
+            .unwrap_or_else(|| panic!("no split module {name:?}"))
+            .1
+    }
+}
+
+/// The `(address, bytes)` of every non-empty active data segment.
+fn data_segments(wasm: &[u8]) -> Vec<(u32, Vec<u8>)> {
+    let mut segments = vec![];
+    for payload in Parser::new(0).parse_all(wasm) {
+        let Payload::DataSection(reader) = payload.expect("valid wasm") else {
+            continue;
+        };
+        for segment in reader {
+            let segment = segment.expect("valid data segment");
+            if segment.data.is_empty() {
+                continue;
+            }
+            let DataKind::Active { offset_expr, .. } = segment.kind else {
+                panic!("expected active data segments only");
+            };
+            let Operator::I32Const { value } = offset_expr
+                .get_operators_reader()
+                .read()
+                .expect("offset expression")
+            else {
+                panic!("expected a constant segment offset");
+            };
+            segments.push((value as u32, segment.data.to_vec()));
+        }
+    }
+    segments
+}
+
+/// A data segment's `(address, bytes)`, or `None` if it is empty.
+type MaybeSegment = Option<(u32, Vec<u8>)>;
+
+/// Every data segment of a module in order, and the data count.
+fn all_data_segments(wasm: &[u8]) -> (Vec<MaybeSegment>, u32) {
+    let mut segments = vec![];
+    let mut count = None;
+    for payload in Parser::new(0).parse_all(wasm) {
+        match payload.expect("valid wasm") {
+            Payload::DataCountSection { count: c, .. } => count = Some(c),
+            Payload::DataSection(reader) => {
+                for segment in reader {
+                    let segment = segment.expect("valid data segment");
+                    let DataKind::Active { offset_expr, .. } = segment.kind else {
+                        panic!("expected active data segments only");
+                    };
+                    let Operator::I32Const { value } = offset_expr
+                        .get_operators_reader()
+                        .read()
+                        .expect("offset expression")
+                    else {
+                        panic!("expected a constant segment offset");
+                    };
+                    segments.push(
+                        (!segment.data.is_empty()).then(|| (value as u32, segment.data.to_vec())),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+    (segments, count.expect("a data count section"))
+}
+
+/// The one non-empty data segment of a module.
+fn single_data_segment(wasm: &[u8]) -> (u32, Vec<u8>) {
+    let mut segments = data_segments(wasm);
+    assert_eq!(
+        segments.len(),
+        1,
+        "expected exactly one non-empty data segment, got {segments:?}"
+    );
+    segments.pop().unwrap()
+}
+
+/// The `i32.const` immediates of every defined function, in function order.
+fn function_constants(wasm: &[u8]) -> Vec<Vec<u32>> {
+    let mut functions = vec![];
+    for payload in Parser::new(0).parse_all(wasm) {
+        let Payload::CodeSectionEntry(body) = payload.expect("valid wasm") else {
+            continue;
+        };
+        let mut constants = vec![];
+        let mut ops = body.get_operators_reader().expect("operators");
+        while !ops.eof() {
+            if let Operator::I32Const { value } = ops.read().expect("op") {
+                constants.push(value as u32);
+            }
+        }
+        functions.push(constants);
+    }
+    functions
+}
+
+/// The `i32.const` immediates of the defined function exported as `export_name`.
+fn exported_function_constants(wasm: &[u8], export_name: &str) -> Vec<u32> {
+    let mut import_count = 0;
+    let mut target = None;
+    for payload in Parser::new(0).parse_all(wasm) {
+        match payload.expect("valid wasm") {
+            Payload::ImportSection(reader) => {
+                for import in reader {
+                    let Ok(wasmparser::Imports::Single(_, import)) = import else {
+                        panic!("valid import")
+                    };
+                    if matches!(import.ty, wasmparser::TypeRef::Func(_)) {
+                        import_count += 1;
+                    }
+                }
+            }
+            Payload::ExportSection(reader) => {
+                for export in reader {
+                    let export = export.expect("valid export");
+                    if export.name == export_name && export.kind == wasmparser::ExternalKind::Func {
+                        target = Some(export.index as usize);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    let index = target.unwrap_or_else(|| panic!("export {export_name:?} not found"));
+    function_constants(wasm).swap_remove(index - import_count)
+}
+
+/// Split modules export nothing; their entry is reached through the function
+/// table. Asserts that some function of `wasm` has exactly these constants.
+fn assert_some_function_refers_to(wasm: &[u8], constants: &[u32]) {
+    let functions = function_constants(wasm);
+    assert!(
+        functions.contains(&constants.to_vec()),
+        "expected a function referring to {constants:?}, got {functions:?}",
+    );
+}
+
+#[test]
+fn shared_data_symbols_are_emitted_once_and_split_data_is_relocated() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let mut data = SHARED.to_vec();
+    data.extend_from_slice(SPLIT_ONLY);
+    let input = Input {
+        data,
+        alignment: 0,
+        symbols: vec![
+            DataSymbol(
+                "shared_tail",
+                SHARED_TAIL_OFFSET,
+                SHARED.len() - SHARED_TAIL_OFFSET,
+            ),
+            DataSymbol("shared_full", 0, SHARED.len()),
+            DataSymbol("split_only", SHARED.len(), SPLIT_ONLY.len()),
+        ],
+        funcs: vec![
+            Func(Owner::Main("main_reads"), vec![0]),
+            Func(Owner::Split("testsplit"), vec![1, 2]),
+        ],
+        extra_segments: vec![],
+        data_relocs: vec![],
+    };
+    let output = split(&input);
+
+    // --- Assertion 1: the shared bytes exist once, in the main module.
+    assert_eq!(
+        single_data_segment(&output.main),
+        (SEGMENT_BASE, SHARED.to_vec()),
+        "main module should contain exactly the shared bytes at the segment base",
+    );
+    assert_eq!(
+        exported_function_constants(&output.main, "main_reads"),
+        vec![SEGMENT_BASE + SHARED_TAIL_OFFSET as u32]
+    );
+
+    // --- Assertion 2: the split-only bytes moved into the split module, and
+    // its function refers to the main module's copy of the shared bytes.
+    let split_module = output.split("testsplit");
+    let (split_only_addr, split_only_bytes) = single_data_segment(split_module);
+    assert_eq!(split_only_bytes, SPLIT_ONLY);
+    assert!(
+        split_only_addr >= SEGMENT_BASE + SHARED.len() as u32,
+        "split data must not overlap the main module's data",
+    );
+    assert!(
+        split_only_addr + SPLIT_ONLY.len() as u32 <= SEGMENT_BASE + input.data.len() as u32,
+        "relocated segment must not grow past its input",
+    );
+    assert_some_function_refers_to(split_module, &[SEGMENT_BASE, split_only_addr]);
+}
+
+#[test]
+fn overlapping_symbols_keep_the_strictest_alignment() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let input = Input {
+        // four unreferenced bytes leave room for the parts to be aligned
+        data: b"ABCDEFGx....".to_vec(),
+        alignment: 2,
+        symbols: vec![
+            DataSymbol("whole", 0, 7),
+            DataSymbol("word", 0, 4),
+            DataSymbol("main_byte", 7, 1),
+        ],
+        funcs: vec![
+            Func(Owner::Main("main_reads"), vec![2]),
+            Func(Owner::Split("a"), vec![0, 1]),
+        ],
+        extra_segments: vec![],
+        data_relocs: vec![],
+    };
+    let output = split(&input);
+
+    let split_a = output.split("a");
+    let (a_addr, a_bytes) = single_data_segment(split_a);
+    assert_eq!(a_bytes, b"ABCDEFG");
+    assert_eq!(
+        a_addr % 4,
+        0,
+        "the word inside the merged range must stay 4-aligned"
+    );
+    assert_some_function_refers_to(split_a, &[a_addr, a_addr]);
+
+    let (main_addr, main_bytes) = single_data_segment(&output.main);
+    assert_eq!(main_bytes, b"x");
+    assert!(
+        main_addr >= a_addr + 7 || main_addr < a_addr,
+        "parts must not overlap"
+    );
+    assert_eq!(
+        exported_function_constants(&output.main, "main_reads"),
+        vec![main_addr]
+    );
+}


### PR DESCRIPTION
In release builds practically all `.rodata` stayed in the main wasm and nothing was
relocated into split modules (leptos-rs/cargo-leptos#679).

wasm-ld deduplicates and tail-merges strings when optimizing, so several data
symbols share bytes, and those symbols do not always land in the same output
module. The layout was computed per module, so shared bytes were copied once per
module, the segment grew past its input and the whole segment fell back into main.

Changes, one per commit:

- Lay out the data symbols of all modules at once and merge overlapping symbols
  into one range, keeping every symbol's alignment. Bytes shared with main are
  emitted from main.
- Attribute a relocation to the smallest data symbol containing it. A module
  using only an inner symbol used to miss the relocation's target; the old
  fallback hid this.
- Emit bytes shared between splits from the chunk those splits load, not main.
- If a relocated segment still does not fit its input, move the smallest
  module's data into main and retry instead of giving up on the whole segment.
- Place ranges by decreasing alignment so ordinary data needs no padding. Each
  module emits one data segment per run of its ranges; input segments keep their
  indices, extra segments are appended, data count and names follow.

Measured on the leptos `lazy_routes` example (release): main's data section
shrinks from 74,106 to 69,547 bytes, every split and chunk now carries its own
data, shipped gzip sizes are within 0.2% of before, and no `--no-merge-data-segments`
linker flag is needed.
