### PR TITLE
chore: emit performance events

### DIFF
--- a/crates/wasm_split_cli/src/dep_graph.rs
+++ b/crates/wasm_split_cli/src/dep_graph.rs
@@ -9,6 +9,7 @@ use wasmparser::{FunctionBody, Operator, RelocationEntry};
 use crate::{
     read::{GlobalId, InputFuncId, InputModule, MemoryId, SymbolIndex, TableId, TagId},
     reloc::{DataSymbol, RelocDetails},
+    tracing_support::perf_span,
     util::{shift_range, wasm_reloc_range},
 };
 
@@ -30,6 +31,9 @@ pub struct Dependencies {
 }
 
 pub fn get_dependencies(module: &InputModule) -> Result<Dependencies> {
+    let perf_span = perf_span!("gather dependencies");
+    let _perf_span = perf_span.enter();
+
     struct Builder<'a, 'm>(DepGraph, &'a InputModule<'m>);
     impl Builder<'_, '_> {
         fn add_dep(&mut self, a: DepNode, b: DepNode) {
@@ -60,12 +64,17 @@ pub fn get_dependencies(module: &InputModule) -> Result<Dependencies> {
     let mut deps = Builder(DepGraph::new(), module);
     let mut fns_with_relocs = HashSet::<InputFuncId>::new();
 
+    let perf_span = perf_span!("function deps from relocs");
+    let perf_span = perf_span.enter();
     for dep_entry in iter_functions_with_relocs(module) {
         let (func_index, entry) = dep_entry?;
         fns_with_relocs.insert(func_index);
         deps.add_reloc_dep(DepNode::Function(func_index), entry)?;
     }
+    perf_span.exit();
 
+    let perf_span = perf_span!("stub function check");
+    let perf_span = perf_span.enter();
     // See issue #29 for why we detect stub functions that aren't covered by reloc data
     let mut stub_fns = HashSet::<InputFuncId>::new();
     let imported_fns_len = module.imported_funcs.len();
@@ -94,7 +103,10 @@ pub fn get_dependencies(module: &InputModule) -> Result<Dependencies> {
             );
         }
     }
+    perf_span.exit();
 
+    let perf_span = perf_span!("data dependencies");
+    let perf_span = perf_span.enter();
     for dep_entry in iter_data_dependencies(module) {
         match dep_entry? {
             DataDependency::Reloc(data_symbol, entry) => {
@@ -129,13 +141,17 @@ pub fn get_dependencies(module: &InputModule) -> Result<Dependencies> {
             }
         }
     }
+    perf_span.exit();
 
+    let perf_span = perf_span!("globals");
+    let perf_span = perf_span.enter();
     for (&global_index, &symbol_index) in &module.reloc_info.symbol_as_global {
         deps.add_dep(
             DepNode::Global(global_index),
             DepNode::DataSymbol(symbol_index),
         );
     }
+    perf_span.exit();
 
     // Global symbols exporting the memory address of a symbol depend on that symbols
     Ok(Dependencies {

--- a/crates/wasm_split_cli/src/emit.rs
+++ b/crates/wasm_split_cli/src/emit.rs
@@ -10,6 +10,7 @@ use crate::{
     read::{InputFuncId, InputModule, InputOffset},
     reloc::{RelocDetails, RelocInfo, RelocTarget},
     split_point::{SplitModuleIdentifier, SplitProgramInfo},
+    tracing_support::perf_span,
     util::{wasm_data_len, wasm_data_start},
 };
 use eyre::{bail, Context, Result};
@@ -732,6 +733,11 @@ impl<'a> ModuleEmitState<'a> {
         output_module_index: usize,
         program_info: &'a crate::split_point::SplitProgramInfo,
     ) -> Self {
+        let perf_span = perf_span!(
+            "build module emit state",
+            module_index = output_module_index
+        );
+        let _perf_span = perf_span.enter();
         let (_, output_module_info) = &program_info.output_modules[output_module_index];
 
         let mut num_func_imports = 0;
@@ -933,6 +939,8 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate(&mut self) -> Result<()> {
+        let perf_span = perf_span!("generate wasm", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
         // Encode sections. These must occur in order
         // most custom sections at the end. The wasm standard doesn't specify a (partial) order, but llvm does
         // reference: https://github.com/llvm/llvm-project/blob/b5fa9eee6798b678fc7cb5f2b42a977932b708f9/llvm/lib/Object/WasmObjectFile.cpp#L2212-L2220
@@ -964,6 +972,8 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_type_section(&mut self) -> Result<()> {
+        let perf_span = perf_span!("type section", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
         // Simply copy all types.  Unneeded types may be pruned by `wasm-opt`.
         let mut section = wasm_encoder::TypeSection::new();
         for input_func_type in self.input_module.types.iter() {
@@ -979,6 +989,8 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_import_section(&mut self) {
+        let perf_span = perf_span!("import section", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
         let mut section = wasm_encoder::ImportSection::new();
         for imp in &self.imports {
             let module = if imp.module == magic_constants::PLACEHOLDER_IMPORT_MODULE {
@@ -1003,6 +1015,8 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_function_section(&mut self) {
+        let perf_span = perf_span!("function section", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
         let mut section = wasm_encoder::FunctionSection::new();
         for defined_func in self.defined_functions.iter() {
             let func_ty = match defined_func {
@@ -1018,6 +1032,8 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_table_section(&mut self) {
+        let perf_span = perf_span!("table section", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
         if !self.is_main() {
             return;
         }
@@ -1040,6 +1056,8 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_global_section(&mut self) -> Result<()> {
+        let perf_span = perf_span!("global section", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
         if !self.is_main() {
             return Ok(());
         }
@@ -1097,6 +1115,8 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_export_section(&mut self) {
+        let perf_span = perf_span!("export section", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
         // shared functions are "exported" by placing them in the indirect_function_table.
         // shared globals are always exported from main
         let mut section = wasm_encoder::ExportSection::new();
@@ -1107,6 +1127,8 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_start_section(&mut self) {
+        let perf_span = perf_span!("start section", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
         if !self.is_main() {
             return;
         }
@@ -1122,6 +1144,9 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_element_section(&mut self) -> Result<()> {
+        let perf_span = perf_span!("element section", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
+
         let indirect_range = &self
             .emit_state
             .indirect_functions
@@ -1241,6 +1266,8 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_code_section(&mut self) -> Result<()> {
+        let perf_span = perf_span!("code section", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
         tracing::debug!(
             module = self.output_module_index,
             defined_count = self.defined_functions.len(),
@@ -1339,6 +1366,8 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_data_section(&mut self) -> Result<()> {
+        let perf_span = perf_span!("data section", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
         let data_reloc = &self.emit_state.data_relocations;
         let mut section = wasm_encoder::DataSection::new();
         for (segment_idx, segment) in data_reloc.per_segment.iter().enumerate() {
@@ -1415,6 +1444,9 @@ impl<'a> ModuleEmitState<'a> {
     }
 
     fn generate_name_section(&mut self) -> Result<()> {
+        let perf_span = perf_span!("name section", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
+
         fn convert_name_map(parser_map: &wasmparser::NameMap<'_>) -> Result<wasm_encoder::NameMap> {
             let mut encoder_map = wasm_encoder::NameMap::new();
             for r in parser_map.clone().into_iter() {
@@ -1553,6 +1585,8 @@ impl<'a> ModuleEmitState<'a> {
         if !self.emit_state.input_options.emit_dwarf {
             return Ok(());
         }
+        let perf_span = perf_span!("debug section", module_index = self.output_module_index);
+        let _perf_span = perf_span.enter();
         dwarf::emit_debug_info(self)
     }
 }
@@ -1620,6 +1654,12 @@ pub fn emit_modules<'info, M>(
     let modules = program_info.output_modules.iter().enumerate();
     modules
         .map(|(output_module_index, (identifier, module))| {
+            let emit_span = perf_span!(
+                "emit module",
+                index = output_module_index,
+                data_size = tracing::field::Empty
+            );
+            let _emit_span = emit_span.enter();
             if module.is_empty {
                 return Ok(None);
             }
@@ -1630,11 +1670,9 @@ pub fn emit_modules<'info, M>(
                 .generate()
                 .with_context(|| format!("Error generating {:?}", identifier))?;
 
-            Ok(Some(emit_fn(
-                output_module_index,
-                identifier,
-                emit_state.output_module.finish(),
-            )))
+            let data = emit_state.output_module.finish();
+            emit_span.record("data_size", data.len());
+            Ok(Some(emit_fn(output_module_index, identifier, data)))
         })
         .filter_map(|res| res.transpose())
         .collect()

--- a/crates/wasm_split_cli/src/js.rs
+++ b/crates/wasm_split_cli/src/js.rs
@@ -6,6 +6,7 @@ use crate::{
     emit::EmitState,
     read::InputModule,
     split_point::{OutputModuleInfo, SplitModuleIdentifier, SplitProgramInfo},
+    tracing_support::perf_span,
 };
 
 type PrefetchMap = HashMap<String, Vec<String>>;
@@ -204,6 +205,8 @@ pub fn link_module<'p>(
     program_info: &'p SplitProgramInfo,
     emit_state: &'p EmitState,
 ) -> Result<LinkModuleWriter<'p>> {
+    let js_emit_span = perf_span!("emit js");
+    let _emit_span = js_emit_span.enter();
     let mut link_module = LinkModuleWriter::new(program_info, emit_state);
 
     let (_, main_module) = program_info

--- a/crates/wasm_split_cli/src/lib.rs
+++ b/crates/wasm_split_cli/src/lib.rs
@@ -15,9 +15,12 @@ mod options;
 mod read;
 mod reloc;
 mod split_point;
+mod tracing_support;
 mod util;
 
 pub use options::*;
+
+use tracing_support::perf_span;
 
 #[non_exhaustive]
 pub struct SplitWasm {
@@ -34,15 +37,21 @@ pub fn transform(opts: Options) -> Result<SplitWasm> {
         read::Strictness::Lenient
     };
     // (1) parse input
+    let parse_span = perf_span!("parse");
+    let parse_span = parse_span.enter();
     let module = crate::read::InputModule::parse(opts.input_wasm, strictness)?;
+    parse_span.exit();
     if opts.verbose {
         module.reloc_info.print_relocs();
     }
     // (2) dependency analysis and decide on splits
+    let deps_span = perf_span!("dependency-analysis");
+    let deps_span = deps_span.enter();
     let deps = dep_graph::get_dependencies(&module)?;
     let split_points = split_point::get_split_points(&module)?;
     let split_program_info =
         split_point::compute_split_modules(&module, &deps.graph, split_points)?;
+    deps_span.exit();
 
     if split_point::trace_enabled(opts.verbose) {
         for (name, split_deps) in split_program_info.output_modules.iter() {
@@ -50,6 +59,8 @@ pub fn transform(opts: Options) -> Result<SplitWasm> {
         }
     }
     // (3) compute output modules and helper javascript
+    let emit_span = perf_span!("emit");
+    let emit_span = emit_span.enter();
     let link_module = opts.link_name;
     let emit_state = emit::EmitState::new(
         &opts,
@@ -72,7 +83,10 @@ pub fn transform(opts: Options) -> Result<SplitWasm> {
         },
     )?;
     let js_link_module = js::link_module(opts.main_module, &split_program_info, &emit_state)?;
+    emit_span.exit();
     // (4) write the output
+    let write_span = perf_span!("write");
+    let write_span = write_span.enter();
     std::fs::create_dir_all(opts.output_dir)?;
     let mut split_modules = vec![];
     for (identifier, output_path, data) in wasm_modules {
@@ -84,6 +98,7 @@ pub fn transform(opts: Options) -> Result<SplitWasm> {
         }
     }
     let prefetch_map = js_link_module.emit(&opts.output_dir.join(Path::new(link_module)))?;
+    write_span.exit();
 
     Ok(SplitWasm {
         split_modules,

--- a/crates/wasm_split_cli/src/reloc.rs
+++ b/crates/wasm_split_cli/src/reloc.rs
@@ -15,6 +15,7 @@ use wasmparser::{
 use crate::{
     magic_constants,
     read::{GlobalId, InputFuncId, InputModule, InputOffset, SectionId, TableId, TagId},
+    tracing_support::perf_span,
     util::{find_subrange, shift_range, wasm_reloc_range},
 };
 
@@ -32,6 +33,8 @@ pub struct RelocInfoParser<'a> {
 
 impl<'a> RelocInfoParser<'a> {
     fn visit_linking(&mut self, subsection: Linking<'a>) -> Result<()> {
+        let perf_span = perf_span!("visit linking section");
+        let _perf_span = perf_span.enter();
         match subsection {
             Linking::SegmentInfo(segments) => {
                 ensure!(self.info.segments.is_empty(), "duplicate segments info");
@@ -69,6 +72,8 @@ impl<'a> RelocInfoParser<'a> {
                 Ok(true)
             }
             KnownCustom::Reloc(reader) => {
+                let perf_span = perf_span!("visit reloc section");
+                let _perf_span = perf_span.enter();
                 let mut reloc_entries = reader
                     .entries()
                     .into_iter()
@@ -135,6 +140,8 @@ fn get_indirect_functions(
     iftable: TableId,
     module: &InputModule,
 ) -> Result<()> {
+    let perf_span = perf_span!("collect indirect functions");
+    let _perf_span = perf_span.enter();
     let mut input_indirect_funcs = HashSet::new();
     for elems in &module.elements {
         let ElementKind::Active {
@@ -204,6 +211,8 @@ pub struct DataSymbol {
 }
 
 fn get_data_symbols(data_segments: &[Data], symbols: &[SymbolInfo]) -> Result<Vec<DataSymbol>> {
+    let perf_span = perf_span!("get data symbols");
+    let _perf_span = perf_span.enter();
     let mut data_symbols = Vec::new();
     for (symbol_index, info) in symbols.iter().enumerate() {
         let SymbolInfo::Data {
@@ -239,6 +248,8 @@ fn get_data_symbols(data_segments: &[Data], symbols: &[SymbolInfo]) -> Result<Ve
 }
 
 fn reconstruct_global_symbols(reloc_info: &mut RelocInfo<'_>, module: &InputModule) -> Result<()> {
+    let perf_span = perf_span!("reconstruct global symbols");
+    let _perf_span = perf_span.enter();
     let symbol_as_global = &mut reloc_info.symbol_as_global;
     debug_assert!(
         symbol_as_global.is_empty(),

--- a/crates/wasm_split_cli/src/split_point.rs
+++ b/crates/wasm_split_cli/src/split_point.rs
@@ -4,6 +4,7 @@ use std::hash::{DefaultHasher, Hasher};
 use crate::dep_graph::{DepGraph, DepNode};
 use crate::graph_utils::tarjan_scc::{SccEvent, SccId, TarjanSccResult};
 use crate::read::{ExportId, ImportId, InputFuncId, InputModule};
+use crate::tracing_support::perf_span;
 use eyre::{anyhow, bail, Result};
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -20,6 +21,9 @@ pub struct SplitPoint {
 }
 
 pub fn get_split_points(module: &InputModule) -> Result<Vec<SplitPoint>> {
+    let perf_span = perf_span!("discover split points");
+    let _perf_span = perf_span.enter();
+
     macro_rules! process_imports_or_exports {
         ($pattern:expr, $map:ident, $member:ident, $id_ty:ty) => {
             let mut $map = HashMap::<(String, String), $id_ty>::new();
@@ -471,6 +475,9 @@ pub fn compute_split_modules(
     dep_graph: &DepGraph,
     split_points: Vec<SplitPoint>,
 ) -> Result<SplitProgramInfo> {
+    let perf_span = perf_span!("compute splits");
+    let _perf_span = perf_span.enter();
+
     let split_points_by_module = get_split_points_by_module(&split_points);
 
     trace!("split_points={split_points:?}");
@@ -490,10 +497,15 @@ pub fn compute_split_modules(
     // Determine reachable symbols (excluding main module symbols) for each
     // split module. Symbols may be reachable from more than one split module;
     // these symbols will be moved to a separate module.
+    let perf_span = perf_span!("explore module", module = "<main>");
+    let perf_span = perf_span.enter();
     let main_roots = get_main_module_roots(module, &split_points);
     graph_analysis.explore(main_roots, SplitModuleIdentifier::Main);
+    perf_span.exit();
 
     for (module_name, entry_points) in &split_points_by_module {
+        let perf_span = perf_span!("explore module", module = module_name);
+        let _perf_span = perf_span.enter();
         let roots = get_split_roots(entry_points);
         graph_analysis.explore(roots, SplitModuleIdentifier::Split(module_name.clone()));
     }
@@ -501,6 +513,8 @@ pub fn compute_split_modules(
     let mut program_info = SplitProgramInfo::default();
     // We "paint" each dependency with the modules it must be loaded in, then put them into that module
     // accordingly.
+    let perf_span = perf_span!("paint dep nodes");
+    let perf_span = perf_span.enter();
     let mut painter = graph_analysis.into_painter();
     let mut split_module_contents = HashMap::<SplitModuleIdentifier, OutputModuleInfo>::new();
     while let Some((node, color)) = painter.next() {
@@ -523,9 +537,12 @@ pub fn compute_split_modules(
             program_info.needs_shim_in_main.insert(func_id);
         }
     }
+    perf_span.exit();
 
     // Now, check for each module which of its dependencies it needs to import from some other module.
-    for out_module in split_module_contents.values_mut() {
+    for (name, out_module) in split_module_contents.iter_mut() {
+        let perf_span = perf_span!("discover shared deps", module = ?name);
+        let _perf_span = perf_span.enter();
         let needed_symbols = out_module
             .included_symbols
             .iter()
@@ -593,6 +610,8 @@ pub fn compute_split_modules(
         .output_modules
         .sort_unstable_by_key(|(identifier, _)| (*identifier).clone());
 
+    let perf_span = perf_span!("build reverse lookup");
+    let perf_span = perf_span.enter();
     for (output_index, (_, info)) in program_info.output_modules.iter().enumerate() {
         for &symbol in info.included_symbols.iter() {
             program_info
@@ -600,14 +619,18 @@ pub fn compute_split_modules(
                 .insert(symbol, output_index);
         }
     }
+    perf_span.exit();
 
     // This exact implementation can differ between different compilations of the CLI, specifically
     // between rust versions. That is fine and intended.
+    let perf_span = perf_span!("canary fingerprint");
+    let perf_span = perf_span.enter();
     let mut hasher = DefaultHasher::new();
     hasher.write(env!("CARGO_PKG_VERSION").as_bytes()); // TODO: hasher.write_str(_) once that's stabilized
     hasher.write(module.raw);
     // once options impact the output module, these should be hashed too
     program_info.canary_export_name = format!("__canary_{:x}", hasher.finish());
+    perf_span.exit();
 
     Ok(program_info)
 }

--- a/crates/wasm_split_cli/src/tracing_support.rs
+++ b/crates/wasm_split_cli/src/tracing_support.rs
@@ -1,0 +1,41 @@
+use tracing::{field, span::Entered, Span};
+
+pub struct TraceCtx {
+    span: Option<Span>,
+}
+pub struct Guard<'a> {
+    inner: Option<Entered<'a>>,
+}
+impl TraceCtx {
+    pub fn new(span: Option<Span>) -> Self {
+        Self { span }
+    }
+    pub fn enter(&self) -> Guard<'_> {
+        Guard {
+            inner: self.span.as_ref().map(|span| span.enter()),
+        }
+    }
+    pub fn record<Q: field::AsField + ?Sized, V: field::Value>(&self, field: &Q, value: V) {
+        if let Some(span) = self.span.as_ref() {
+            span.record(field, value);
+        }
+    }
+}
+impl Guard<'_> {
+    pub fn exit(self) {
+        let _ = self.inner;
+    }
+}
+
+macro_rules! perf_span {
+    ($name:expr $(, $($fields:tt)* )?) => {
+        $crate::tracing_support::TraceCtx::new(
+            if ::tracing::span_enabled!(::tracing::Level::ERROR, perf_key = $name, $( $($fields)* )? ) {
+                Some(::tracing::span!(::tracing::Level::TRACE, $name, perf_key = $name, $( $($fields)* )? ))
+            } else {
+                None
+            }
+        )
+    };
+}
+pub(crate) use perf_span;

--- a/test-runner/Cargo.lock
+++ b/test-runner/Cargo.lock
@@ -1019,6 +1019,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,7 +1754,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1775,10 +1807,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -2040,6 +2076,8 @@ dependencies = [
  "serde_with",
  "sha2",
  "tempfile",
+ "tracing",
+ "tracing-chrome",
  "tracing-subscriber",
  "wasm-bindgen-cli",
  "wasm_split_cli_support",

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -15,7 +15,9 @@ wasm-bindgen-cli = { version = "=0.2.128", artifact = ["bin:wasm-bindgen-test-ru
 wasm_split_cli_support = { path = "../crates/wasm_split_cli" }
 eyre = "0.6.12"
 tempfile = "3.27.0"
-tracing-subscriber = { version = "0.3.23", features = ["fmt"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3.23", features = ["fmt", "env-filter"] }
+tracing-chrome = "0.7.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 serde_with = "3.21.0"

--- a/test-runner/src/bin/wasm-split-test-runner.rs
+++ b/test-runner/src/bin/wasm-split-test-runner.rs
@@ -8,6 +8,12 @@ use std::{
     process::Command,
     time::{Duration, Instant},
 };
+use tracing::{
+    Subscriber,
+    field::{Field, Visit},
+    span,
+};
+use tracing_subscriber::{layer::Context, registry::LookupSpan};
 
 #[serde_with::serde_as]
 #[derive(Default, serde::Serialize)]
@@ -109,21 +115,93 @@ fn check_reproducible(first_report: &Report, second_report: &Report) -> Result<(
     Ok(())
 }
 
-fn wasm_split_cli(target: &Path, dir: &Path) -> Result<(PathBuf, Report)> {
+fn with_perf_tracing<R>(report_dir: &Path, f: impl FnOnce() -> R) -> R {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::{Layer, filter::FilterFn};
+
+    let fmt = tracing_subscriber::fmt::layer();
+    let fmt = fmt.with_filter(tracing_subscriber::EnvFilter::from_default_env());
+    let perf = tracing_chrome::ChromeLayerBuilder::new();
+    let report_path = report_dir.join(format!(
+        "trace-{}.json",
+        std::time::SystemTime::UNIX_EPOCH
+            .elapsed()
+            .unwrap()
+            .as_micros()
+    ));
+    const PERF_KEY_NAME: &str = "perf_key";
+    struct Name(Field, String);
+    impl Visit for Name {
+        fn record_debug(&mut self, field: &Field, value: &dyn core::fmt::Debug) {
+            use std::fmt::Write;
+            if &self.0 == field {
+                let _ = write!(&mut self.1, "{value:?}");
+            }
+        }
+    }
+    struct SpanNamePerfKey;
+    struct NameExtension(String);
+    impl<S: Subscriber + for<'lookup> LookupSpan<'lookup>> Layer<S> for SpanNamePerfKey {
+        fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+            if let Some(perf_key) = attrs.fields().field(PERF_KEY_NAME) {
+                let mut name = Name(perf_key, String::new());
+                attrs.record(&mut name);
+                let name = name.1;
+                ctx.span(id)
+                    .unwrap()
+                    .extensions_mut()
+                    .insert(NameExtension(name));
+            }
+        }
+    }
+    let perf = perf.file(report_path);
+    let perf = perf.include_args(true);
+    let perf = perf.name_fn(Box::new(|data| match *data {
+        tracing_chrome::EventOrSpan::Event(event) => {
+            if let Some(perf_key) = event.fields().find(|field| field.name() == PERF_KEY_NAME) {
+                let mut name = Name(perf_key, String::new());
+                event.record(&mut name);
+                name.1
+            } else {
+                event.metadata().name().to_string()
+            }
+        }
+        tracing_chrome::EventOrSpan::Span(span_ref) => span_ref
+            .extensions()
+            .get::<NameExtension>()
+            .map(|ext| &ext.0)
+            .cloned()
+            .unwrap_or_else(|| span_ref.metadata().name().to_string()),
+    }));
+    let (perf, perf_guard) = perf.build();
+    let perf = SpanNamePerfKey.and_then(perf);
+    let perf = perf.with_filter(FilterFn::new(|metadata| {
+        metadata.fields().field(PERF_KEY_NAME).is_some()
+    }));
+    let subscriber = tracing_subscriber::registry().with(fmt).with(perf);
+    let dispatch = tracing::Dispatch::new(subscriber);
+    let r = tracing::dispatcher::with_default(&dispatch, f);
+    let _ = perf_guard;
+    r
+}
+
+fn wasm_split_cli(target: &Path, dir: &Path, report_dir: &Path) -> Result<(PathBuf, Report)> {
     let main_file = dir.join("main.wasm");
     let input = std::fs::read(target)?;
     let mut report: Report = Report::default();
     let start_time = Instant::now();
 
-    let split = wasm_split_cli_support::transform({
-        let mut split_opts = wasm_split_cli_support::Options::new(&input);
-        split_opts.output_dir = dir;
-        split_opts.main_out_path = &main_file;
-        split_opts.main_module = "./wasm-bindgen-test";
-        split_opts.verbose = true;
-        split_opts.strict_tests = true;
-        split_opts.emit_dwarf = true;
-        split_opts
+    let split = with_perf_tracing(report_dir, || {
+        wasm_split_cli_support::transform({
+            let mut split_opts = wasm_split_cli_support::Options::new(&input);
+            split_opts.output_dir = dir;
+            split_opts.main_out_path = &main_file;
+            split_opts.main_module = "./wasm-bindgen-test";
+            split_opts.verbose = true;
+            split_opts.strict_tests = true;
+            split_opts.emit_dwarf = true;
+            split_opts
+        })
     })?;
     let time_taken = Instant::now().duration_since(start_time);
     report.cli_runtime = time_taken;
@@ -134,11 +212,14 @@ fn wasm_split_cli(target: &Path, dir: &Path) -> Result<(PathBuf, Report)> {
 }
 
 fn find_build_tempdir_root(target: &Path) -> PathBuf {
-    let build_dir = target
-        .parent()
-        .expect("strip executable name")
-        .parent()
-        .expect("strip profile name");
+    let mut candidate = target;
+    let build_dir = loop {
+        let parent = candidate.parent().expect("to find a cachedir tag");
+        if parent.join("CACHEDIR.TAG").exists() {
+            break parent;
+        }
+        candidate = parent;
+    };
     let out_path = build_dir
         .join("wasm-split-integration")
         .join(std::env::var_os("XCARGO_PKG_NAME").expect("pkg name set by runner script"));
@@ -165,13 +246,13 @@ pub fn main() -> Result<()> {
         tempdir.path().display()
     );
 
-    let (split_main, report) = wasm_split_cli(target, tempdir.path())?;
+    let (split_main, report) = wasm_split_cli(target, tempdir.path(), &target_report_dir)?;
     print_report(&report, &target_report_dir)?;
     if !std::env::var_os("XTEST_SKIP_REPRODUCTION").is_some_and(|skip| !skip.is_empty()) {
         // check that the result is reproducible.
         // we could do this in its own directory. However, when the result is reproducible,
         // the second output should not have overwritten anything from the first either way.
-        let (_, second_report) = wasm_split_cli(target, tempdir.path())?;
+        let (_, second_report) = wasm_split_cli(target, tempdir.path(), &target_report_dir)?;
         check_reproducible(&report, &second_report)?;
     }
 


### PR DESCRIPTION
Instrument the code to emit a bit of performance relevant data as tracing events.

The events and spans are collected by [tracing_chrome](https://crates.io/crates/tracing-chrome) in a file that can be loaded in https://ui.perfetto.dev/ to investigate performance. The events should perhaps be supplemented with a bit more information, e.g. the number of functions or found symbols, to facilitate an easier view. All performance events have an attribute name `perf_key` with a relevant name.